### PR TITLE
Various updates, mainly bug fixes and updating tests

### DIFF
--- a/client/cli/common/assignment.py
+++ b/client/cli/common/assignment.py
@@ -50,6 +50,9 @@ class Assignment(core.Serializable):
 
     def post_instantiation(self):
         self._print_header()
+
+    def load(self):
+        """Load tests and protocols."""
         self._load_tests()
         self._load_protocols()
         self._resolve_specified_tests()
@@ -70,9 +73,9 @@ class Assignment(core.Serializable):
             else:
                 parameter = ''
 
-            for file in _find_files(file_pattern):
+            for file in self._find_files(file_pattern):
                 try:
-                    module = _import_module(self._TESTS_PACKAGE + '.' + source)
+                    module = self._import_module(self._TESTS_PACKAGE + '.' + source)
                 except ImportError:
                     raise ex.LoadingException('Invalid test source: {}'.format(source))
 
@@ -148,7 +151,7 @@ class Assignment(core.Serializable):
         log.info('Loading protocols')
         for proto in self.protocols:
             try:
-                module = _import_module(self._PROTOCOL_PACKAGE + '.' + proto)
+                module = self._import_module(self._PROTOCOL_PACKAGE + '.' + proto)
             except ImportError:
                 raise ex.LoadingException('Invalid protocol: {}'.format(proto))
 
@@ -162,11 +165,11 @@ class Assignment(core.Serializable):
         format.print_line('=')
         print()
 
-def _find_files(pattern):
-    return glob.glob(pattern)
+    def _find_files(self, pattern):
+        return glob.glob(pattern)
 
-def _import_module(module):
-    return importlib.import_module(module)
+    def _import_module(self, module):
+        return importlib.import_module(module)
 
 def _has_subsequence(string, pattern):
     """Returns true if the pattern is a subsequence of string."""

--- a/client/cli/common/assignment.py
+++ b/client/cli/common/assignment.py
@@ -68,13 +68,7 @@ class Assignment(core.Serializable):
             else:
                 parameter = ''
 
-
-            files = glob.glob(file_pattern)
-            if not files:
-                raise ex.LoadingException(
-                        'Unable to find file pattern: {}'.format(file_pattern))
-
-            for file in files:
+            for file in glob.glob(file_pattern):
                 try:
                     module = importlib.import_module(self._TESTS_PACKAGE + '.' + source)
                 except ImportError:
@@ -85,6 +79,9 @@ class Assignment(core.Serializable):
                     test_name += ':' + parameter
                 self.test_map[test_name] = module.load(file, parameter, self.cmd_args)
                 log.info('Loaded {}'.format(test_name))
+
+        if not test_map:
+            raise ex.LoadingException('No tests loaded')
 
     def dump_tests(self):
         """Dumps all tests, as determined by their .dump() method.

--- a/client/cli/common/assignment.py
+++ b/client/cli/common/assignment.py
@@ -30,7 +30,7 @@ def get_config(filepath):
         # config.json file in the zip archive
         archive = zipfile.ZipFile('ok')
         config = archive.read('client/config.json').decode('utf-8')
-        return json.loads(config)
+        return json.loads(config, object_pairs_hook=collections.OrderedDict)
 
 class Assignment(core.Serializable):
     name = core.String()
@@ -162,10 +162,10 @@ class Assignment(core.Serializable):
         format.print_line('=')
         print()
 
-def _find_files(self, pattern):
+def _find_files(pattern):
     return glob.glob(pattern)
 
-def _import_module(self, module):
+def _import_module(module):
     return importlib.import_module(module)
 
 def _has_subsequence(string, pattern):

--- a/client/cli/common/assignment.py
+++ b/client/cli/common/assignment.py
@@ -70,9 +70,9 @@ class Assignment(core.Serializable):
             else:
                 parameter = ''
 
-            for file in glob.glob(file_pattern):
+            for file in _find_files(file_pattern):
                 try:
-                    module = importlib.import_module(self._TESTS_PACKAGE + '.' + source)
+                    module = _import_module(self._TESTS_PACKAGE + '.' + source)
                 except ImportError:
                     raise ex.LoadingException('Invalid test source: {}'.format(source))
 
@@ -82,7 +82,7 @@ class Assignment(core.Serializable):
                 self.test_map[test_name] = module.load(file, parameter, self.cmd_args)
                 log.info('Loaded {}'.format(test_name))
 
-        if not test_map:
+        if not self.test_map:
             raise ex.LoadingException('No tests loaded')
 
     def dump_tests(self):
@@ -148,7 +148,7 @@ class Assignment(core.Serializable):
         log.info('Loading protocols')
         for proto in self.protocols:
             try:
-                module = importlib.import_module(self._PROTOCOL_PACKAGE + '.' + proto)
+                module = _import_module(self._PROTOCOL_PACKAGE + '.' + proto)
             except ImportError:
                 raise ex.LoadingException('Invalid protocol: {}'.format(proto))
 
@@ -161,6 +161,12 @@ class Assignment(core.Serializable):
         print('OK, version {}'.format(client.__version__))
         format.print_line('=')
         print()
+
+def _find_files(self, pattern):
+    return glob.glob(pattern)
+
+def _import_module(self, module):
+    return importlib.import_module(module)
 
 def _has_subsequence(string, pattern):
     """Returns true if the pattern is a subsequence of string."""

--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -120,8 +120,9 @@ def main():
     # Load assignment
     try:
         assign = assignment.load_config(args.config, args)
-    except (ex.LoadingException, ex.SerializeException, TypeError) as e:
-        print(str(e))
+    except ex.LoadingException as e:
+        log.warning('Assignment could not load', stack_info=True)
+        print('Error loading assignment')
         exit(1)
     except KeyboardInterrupt:
         print("Quitting ok.")

--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -120,7 +120,7 @@ def main():
     try:
         assign = assignment.load_config(args.config, args)
     except ex.LoadingException as e:
-        log.warning('Assignment could not load', stack_info=True)
+        log.warning('Assignment could not load', exc_info=True)
         print('Error loading assignment')
         exit(1)
     except KeyboardInterrupt:

--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -120,7 +120,7 @@ def main():
     # Load assignment
     try:
         assign = assignment.load_config(args.config, args)
-    except (ex.LoadingException, ex.SerializeException) as e:
+    except (ex.LoadingException, ex.SerializeException, TypeError) as e:
         print(str(e))
         exit(1)
     except KeyboardInterrupt:
@@ -145,6 +145,7 @@ def main():
         for name, proto in assign.protocol_map.items():
             log.info('Execute {}.on_start()'.format(name))
             start_messages[name] = proto.on_start()
+        # TODO(albert): doesn't AnalyticsProtocol store the timestamp?
         start_messages['timestamp'] = str(datetime.now())
 
         # Run protocol.on_interact
@@ -152,6 +153,7 @@ def main():
         for name, proto in assign.protocol_map.items():
             log.info('Execute {}.on_interact()'.format(name))
             interact_msg[name] = proto.on_interact()
+        # TODO(albert): doesn't AnalyticsProtocol store the timestamp?
         interact_msg['timestamp'] = str(datetime.now())
     except KeyboardInterrupt:
         print("Quitting ok.")

--- a/client/exceptions.py
+++ b/client/exceptions.py
@@ -19,7 +19,7 @@ class Timeout(OkException):
         """
         super().__init__(self)
         self.timeout = timeout
-        self.message = _message
+        self.message = self._message
 
 class LoadingException(OkException):
     """Exception related to loading assignments."""

--- a/client/sources/common/core.py
+++ b/client/sources/common/core.py
@@ -1,3 +1,4 @@
+from client import exceptions as ex
 import collections
 
 ###############
@@ -17,7 +18,7 @@ class Field(object):
         if 'default' in kargs:
             value = kargs['default']
             if not self.is_valid(value):
-                raise TypeError('Invalid default: {}'.format(value))
+                raise ex.SerializeException('Invalid default: {}'.format(value))
             self._optional = True
             self._default = value
 
@@ -37,19 +38,19 @@ class Field(object):
         """Subclasses should override this method for type coercion.
 
         Default version will simply return the argument. If the argument
-        is not valid, a TypeError is raised.
+        is not valid, a SerializeException is raised.
 
         For primitives like booleans, ints, floats, and strings, use
         this default version to avoid unintended type conversions."""
         if not self.is_valid(value):
-            raise TypeError('{} is not a valid value for type {}'.format(value,
-                            self.__class__.__name__))
+            raise ex.SerializeException('{} is not a valid value for '
+                                        'type {}'.format(value, self.__class__.__name__))
         return value
 
     def to_json(self, value):
         """Subclasses should override this method for JSON encoding."""
         if not self.is_valid(value):
-            raise TypeError('Invalid value: {}'.format(value))
+            raise ex.SerializeException('Invalid value: {}'.format(value))
         return value
 
 class Boolean(Field):
@@ -88,11 +89,17 @@ class List(Field):
 
     def coerce(self, value):
         if self._type is None:
-            return list(value)
+            try:
+                return list(value)
+            except TypeError as e:
+                raise ex.SerializeException(str(e))
         else:
             # TODO(albert): find a way to do better element-wise type coercion
             # so that constructors can take additional arguments
-            return [self._type(elem) for elem in value]
+            try:
+                return [self._type(elem) for elem in value]
+            except TypeError as e:
+                raise ex.SerializeException(str(e))
 
     def to_json(self, value):
         value = super().to_json(value)
@@ -120,8 +127,13 @@ class Dict(Field):
         return valid
 
     def coerce(self, value):
+        try:
+            coerced = self._constructor(value)
+        except TypeError as e:
+            raise ex.SerializeException(str(e))
+
         result = self._constructor()
-        for k, v in self._constructor(value).items():
+        for k, v in coerced.items():
             if self._keys is not None:
                 k = self._keys(k)
             elif self._values is not None:
@@ -159,7 +171,7 @@ class _SerializeMeta(type):
         # Validate existing arguments
         for attr, value in kargs.items():
             if attr not in cls._fields:
-                raise TypeError('__init__() got an unexpected '
+                raise ex.SerializeException('__init__() got an unexpected '
                                 'keyword argument: {}'.format(attr))
             else:
                 setattr(obj, attr, value)
@@ -170,7 +182,7 @@ class _SerializeMeta(type):
             elif value.optional:
                 setattr(obj, attr, value.default)
             else:
-                raise TypeError('__init__() missing expected '
+                raise ex.SerializeException('__init__() missing expected '
                                 'argument {}'.format(attr))
         obj.post_instantiation()
         return obj

--- a/client/sources/common/core.py
+++ b/client/sources/common/core.py
@@ -42,7 +42,8 @@ class Field(object):
         For primitives like booleans, ints, floats, and strings, use
         this default version to avoid unintended type conversions."""
         if not self.is_valid(value):
-            raise TypeError
+            raise TypeError('{} is not a valid value for type {}'.format(value,
+                            self.__class__.__name__))
         return value
 
     def to_json(self, value):

--- a/client/sources/doctest/__init__.py
+++ b/client/sources/doctest/__init__.py
@@ -45,9 +45,11 @@ def load(file, name, args):
     if not callable(func):
         raise ex.LoadingException('Attribute {} is not a function'.format(name))
 
+    docstring = func.__doc__ if func.__doc__ else ''
+
     try:
         return models.Doctest(file, args.verbose, args.interactive, args.timeout,
-                              name=name, points=1, docstring=func.__doc__)
+                              name=name, points=1, docstring=docstring)
     except ex.SerializeException:
         raise ex.LoadingException('Unable to load doctest for {} '
                                   'from {}'.format(name, file))

--- a/client/sources/doctest/__init__.py
+++ b/client/sources/doctest/__init__.py
@@ -44,5 +44,10 @@ def load(file, name, args):
     func = getattr(module, name)
     if not callable(func):
         raise ex.LoadingException('Attribute {} is not a function'.format(name))
-    return models.Doctest(file, args.verbose, args.interactive, args.timeout,
-                          name=name, points=1, docstring=func.__doc__)
+
+    try:
+        return models.Doctest(file, args.verbose, args.interactive, args.timeout,
+                              name=name, points=1, docstring=func.__doc__)
+    except ex.SerializeException:
+        raise ex.LoadingException('Unable to load doctest for {} '
+                                  'from {}'.format(name, file))

--- a/client/sources/doctest/models.py
+++ b/client/sources/doctest/models.py
@@ -71,9 +71,13 @@ class Doctest(models.Test):
         print('Doctests for {}'.format(self.name))
         print()
 
-        success = self.case.run()
-        if success:
-            print('-- OK! --')
+        if not self.docstring:
+            print('-- No doctests found for {} --'.format(self.name))
+            success = False
+        else:
+            success = self.case.run()
+            if success:
+                print('-- OK! --')
 
         output.on()
         output_log = output.get_log(log_id)

--- a/client/sources/ok_test/__init__.py
+++ b/client/sources/ok_test/__init__.py
@@ -28,6 +28,9 @@ def load(file, parameter, args):
         raise ex.LoadingException('Cannot import {} as an OK test'.format(file))
 
     test = importing.load_module(file).test
-    return models.OkTest(SUITES, args.verbose, args.interactive, args.timeout,
-                         **test)
+    try:
+        return models.OkTest(SUITES, args.verbose, args.interactive,
+                             args.timeout, **test)
+    except ex.SerializeException:
+        raise ex.LoadingException('Cannot load OK test {}'.format(file))
 

--- a/client/sources/ok_test/models.py
+++ b/client/sources/ok_test/models.py
@@ -1,3 +1,4 @@
+from client import exceptions as ex
 from client.sources.common import core
 from client.sources.common import models
 from client.utils import format

--- a/client/utils/format.py
+++ b/client/utils/format.py
@@ -99,5 +99,5 @@ def prettyjson(json, indentation='  '):
             pairs.append(indent(k + ': ' + v, indentation))
         return '{\n' + ',\n'.join(pairs) + '\n}'
     else:
-        raise exceptions.DeserializeError('Invalid json type: {}'.format(json))
+        raise exceptions.SerializeException('Invalid json type: {}'.format(json))
 

--- a/tests/cli/common/assignment_test.py
+++ b/tests/cli/common/assignment_test.py
@@ -38,14 +38,6 @@ class AssignmentTest(unittest.TestCase):
         self.mockTest = mock.Mock()
         self.mockImportModule.return_value.load.return_value = self.mockTest
 
-        self.old_import, self.old_find = assignment._import_module, assignment._find_files
-        assignment._import_module = self.mockImportModule
-        assignment._find_files = self.mockFindFiles
-
-    def tearDown(self):
-        assignment._import_module = self.old_import
-        assignment._find_files = self.old_find
-
     def makeAssignment(self, tests=None, protocols=None):
         if tests is None:
             tests = {self.PATTERN1: self.SOURCE1}
@@ -56,6 +48,7 @@ class AssignmentTest(unittest.TestCase):
                                            tests=tests, protocols=protocols)
         assign._import_module = self.mockImportModule
         assign._find_files = self.mockFindFiles
+        assign.load()
         return assign
 
     def testConstructor_noTestSources(self):

--- a/tests/cli/common/assignment_test.py
+++ b/tests/cli/common/assignment_test.py
@@ -1,0 +1,186 @@
+from client import exceptions as ex
+from client.cli.common import assignment
+import collections
+import mock
+import unittest
+
+class AssignmentTest(unittest.TestCase):
+    NAME = 'Assignment'
+    ENDPOINT = 'endpoint'
+    SRC = ['file1', 'file2']
+
+    PATTERN1 = 'pattern1'
+    PATTERN2 = 'pattern2'
+    PARAMETER = 'param'
+    PATTERN_WITH_PARAM = PATTERN1 + ':' + PARAMETER
+
+    SOURCE1 = 'source1'
+    SOURCE2 = 'source2'
+
+    FILE1 = 'tests/q1.py'
+    FILE2 = 'tests/q2.py'
+    FILES = [FILE1, FILE2]
+    QUESTION1 = 'q1'
+    QUESTION2 = 'tests2'
+    AMBIGUOUS_QUESTION = 'q'
+    INVALID_QUESTION = 'x'
+
+    PROTOCOL = 'protocol'
+
+    def setUp(self):
+        self.cmd_args = mock.Mock()
+        self.cmd_args.question = []
+        self.mockSource1 = mock.Mock()
+        self.mockProtocol1 = mock.Mock()
+
+        self.mockFindFiles = mock.Mock()
+        self.mockImportModule = mock.Mock()
+        self.mockTest = mock.Mock()
+        self.mockImportModule.return_value.load.return_value = self.mockTest
+
+        self.old_import, self.old_find = assignment._import_module, assignment._find_files
+        assignment._import_module = self.mockImportModule
+        assignment._find_files = self.mockFindFiles
+
+    def tearDown(self):
+        assignment._import_module = self.old_import
+        assignment._find_files = self.old_find
+
+    def makeAssignment(self, tests=None, protocols=None):
+        if tests is None:
+            tests = {self.PATTERN1: self.SOURCE1}
+        if protocols is None:
+            protocols = [self.PROTOCOL]
+        assign = assignment.Assignment(self.cmd_args, name=self.NAME,
+                                           endpoint=self.ENDPOINT, src=self.SRC,
+                                           tests=tests, protocols=protocols)
+        assign._import_module = self.mockImportModule
+        assign._find_files = self.mockFindFiles
+        return assign
+
+    def testConstructor_noTestSources(self):
+        self.assertRaises(ex.LoadingException, self.makeAssignment,
+                          tests={})
+
+    def testConstructor_sourceWithNoMatches(self):
+        def selective_pattern_match(pattern):
+            if pattern == self.PATTERN1:
+                return []
+            elif pattern == self.PATTERN2:
+                return [self.FILE1]
+        self.mockFindFiles.side_effect = selective_pattern_match
+
+        assign = self.makeAssignment(tests=collections.OrderedDict((
+            (self.PATTERN1, self.SOURCE1),
+            (self.PATTERN2, self.SOURCE2),
+        )))
+
+        self.assertEqual(collections.OrderedDict((
+            (self.FILE1, self.mockTest),
+        )), assign.test_map)
+
+    def testConstructor_noTestsLoaded(self):
+        self.mockFindFiles.return_value = []
+
+        self.assertRaises(ex.LoadingException, self.makeAssignment)
+
+    def testConstructor_invalidSource(self):
+        self.mockFindFiles.return_value = [self.FILE1]
+        self.mockImportModule.side_effect = ImportError
+
+        self.assertRaises(ex.LoadingException, self.makeAssignment)
+
+    def testConstructor_parameterInTestPattern(self):
+        self.mockFindFiles.return_value = [self.FILE1]
+        assign = self.makeAssignment(tests=collections.OrderedDict((
+            (self.PATTERN_WITH_PARAM, self.SOURCE1),
+        )))
+
+        self.assertEqual(collections.OrderedDict((
+            (self.FILE1 + ':' + self.PARAMETER, self.mockTest),
+        )), assign.test_map)
+
+    def testConstructor_specifiedTest_ambiguousTest(self):
+        self.cmd_args.question = [self.AMBIGUOUS_QUESTION]
+        self.mockFindFiles.return_value = self.FILES
+        self.assertRaises(ex.LoadingException, self.makeAssignment)
+
+    def testConstructor_specifiedTest_invalidTest(self):
+        self.cmd_args.question = [self.INVALID_QUESTION]
+        self.mockFindFiles.return_value = self.FILES
+        self.assertRaises(ex.LoadingException, self.makeAssignment)
+
+    def testConstructor_specifiedTest_match(self):
+        self.cmd_args.question = [self.QUESTION1]
+        self.mockFindFiles.return_value = self.FILES
+        assign = self.makeAssignment()
+
+        self.assertEqual(collections.OrderedDict((
+            (self.FILE1, self.mockTest),
+            (self.FILE2, self.mockTest),
+        )), assign.test_map)
+        self.assertEqual([self.mockTest], assign.specified_tests)
+
+    def testConstructor_specifiedTest_multipleQuestions(self):
+        self.cmd_args.question = [self.QUESTION1, self.QUESTION2]
+        self.mockFindFiles.return_value = self.FILES
+        assign = self.makeAssignment()
+
+        self.assertEqual(collections.OrderedDict((
+            (self.FILE1, self.mockTest),
+            (self.FILE2, self.mockTest),
+        )), assign.test_map)
+        self.assertEqual([self.mockTest, self.mockTest], assign.specified_tests)
+
+    def testConstructor_specifiedTest_noSpecifiedTests(self):
+        self.cmd_args.question = []
+        self.mockFindFiles.return_value = self.FILES
+        assign = self.makeAssignment()
+
+        self.assertEqual(collections.OrderedDict((
+            (self.FILE1, self.mockTest),
+            (self.FILE2, self.mockTest),
+        )), assign.test_map)
+        self.assertEqual([self.mockTest, self.mockTest], assign.specified_tests)
+
+    def testConstructor_invalidProtocol(self):
+        def import_module(module):
+            if self.PROTOCOL in module:
+                raise ImportError
+            else:
+                result = mock.Mock()
+                result.load.return_value = self.mockTest
+                return result
+        self.mockImportModule.side_effect = import_module
+        self.mockFindFiles.return_value = [self.FILE1]
+
+        self.assertRaises(ex.LoadingException, self.makeAssignment)
+
+    def testConstructor_noProtocols(self):
+        self.mockFindFiles.return_value = [self.FILE1]
+
+        try:
+            self.makeAssignment(protocols=[])
+        except ex.LoadingException:
+            self.fail('It is ok for no protocols to be specified')
+
+    def testDumpTests(self):
+        self.mockFindFiles.return_value = self.FILES
+        assign = self.makeAssignment()
+
+        assign.dump_tests()
+        self.assertEqual(2, self.mockTest.dump.call_count)
+        self.mockTest.dump.assert_has_calls([
+            mock.call(self.FILE1),
+            mock.call(self.FILE2)
+        ])
+
+    def testDumpTests_serializeError(self):
+        self.mockFindFiles.return_value = self.FILES
+        assign = self.makeAssignment()
+        self.mockTest.dump.side_effect = ex.SerializeException
+
+        try:
+            assign.dump_tests()
+        except ex.SerializeException:
+            self.fail('If one test fails to dump, continue dumping the rest.')

--- a/tests/protocols/grading_test.py
+++ b/tests/protocols/grading_test.py
@@ -18,7 +18,13 @@ class GradingProtocolTest(unittest.TestCase):
         self.assertIsInstance(results, dict)
 
     def testOnInteract_withTests(self):
-        self.assignment.specified_tests = [mock.Mock(spec=models.Test)]
+        test = mock.Mock(spec=models.Test)
+        test.run.return_value = {
+            'passed': 0,
+            'failed': 0,
+            'locked': 0,
+        }
+        self.assignment.specified_tests = [test]
         results = self.proto.on_interact()
         self.assertIsInstance(results, dict)
 

--- a/tests/sources/common/core_test.py
+++ b/tests/sources/common/core_test.py
@@ -1,3 +1,4 @@
+from client import exceptions as ex
 from client.sources.common import core
 import mock
 import unittest
@@ -30,7 +31,8 @@ class FieldTest(unittest.TestCase):
         self.assertEqual(field.default, MockField.VALID_INT)
 
     def testDefaultArgument_invalidDefault(self):
-        self.assertRaises(TypeError, MockField, default=MockField.INVALID_INT)
+        self.assertRaises(ex.SerializeException, MockField,
+                          default=MockField.INVALID_INT)
 
     def testDefaultArgument_optionalFalse(self):
         field = MockField(optional=False, default=MockField.VALID_INT)
@@ -49,7 +51,8 @@ class FieldTest(unittest.TestCase):
 
     def testToJson_invalidValue(self):
         field = MockField()
-        self.assertRaises(TypeError, field.to_json, MockField.INVALID_INT)
+        self.assertRaises(ex.SerializeException, field.to_json,
+                          MockField.INVALID_INT)
 
 
 class ListFieldTest(unittest.TestCase):
@@ -85,7 +88,7 @@ class ListFieldTest(unittest.TestCase):
 
     def assertCoerce_errors(self, value, **fields):
         field = core.List(**fields)
-        self.assertRaises((TypeError, ValueError), field.coerce, value)
+        self.assertRaises(ex.SerializeException, field.coerce, value)
 
     def testCoerce_heterogeneousList(self):
         lst = [1, 'hi', 3, True]
@@ -179,7 +182,7 @@ class DictFieldTest(unittest.TestCase):
 
     def assertCoerce_errors(self, value, **fields):
         field = core.Dict(**fields)
-        self.assertRaises((TypeError, ValueError), field.coerce, value)
+        self.assertRaises(ex.SerializeException, field.coerce, value)
 
     def testCoerce_heterogeneousDict(self):
         d = {'a': 1, 2: False}
@@ -268,29 +271,29 @@ class SerializableTest(unittest.TestCase):
     TEST_STR = 'hi'
 
     def testConstructor_missingRequiredFields(self):
-        self.assertRaises(TypeError, MockSerializable)
+        self.assertRaises(ex.SerializeException, MockSerializable)
 
     def testConstructor_incorrectRequiredFields(self):
-        self.assertRaises(TypeError, MockSerializable, var1=self.TEST_INT)
+        self.assertRaises(ex.SerializeException, MockSerializable, var1=self.TEST_INT)
 
     def testConstructor_incorrectOptionalFields(self):
-        self.assertRaises(TypeError, MockSerializable, var1=self.TEST_BOOL,
+        self.assertRaises(ex.SerializeException, MockSerializable, var1=self.TEST_BOOL,
                           var2=self.TEST_BOOL)
 
     def testConstructor_unexpectedFields(self):
-        self.assertRaises(TypeError, MockSerializable, var1=self.TEST_BOOL,
+        self.assertRaises(ex.SerializeException, MockSerializable, var1=self.TEST_BOOL,
                           var2=self.TEST_INT, foo=self.TEST_INT)
 
     def testConstructor_validArguments(self):
         try:
             MockSerializable(var1=self.TEST_BOOL, var3=self.TEST_STR)
-        except TypeError:
+        except ex.SerializeException:
             self.fail("Should not have failed")
 
     def testConstructor_overrideSuperclassFields(self):
         try:
             obj = MockSerializable2(var1=self.TEST_BOOL)
-        except TypeError:
+        except ex.SerializeException:
             self.fail("Should not have failed")
 
         self.assertEqual(MockSerializable2.TEST_INT, obj.var2)
@@ -310,10 +313,10 @@ class SerializableTest(unittest.TestCase):
         obj = MockSerializable(var1=self.TEST_BOOL, var3=self.TEST_STR)
         try:
             obj.var1 = self.TEST_INT
-        except TypeError:
+        except ex.SerializeException:
             pass
         else:
-            self.fail("Should have raised a TypeError")
+            self.fail("Should have raised a SerializeException")
 
     def testToJson_noOptional(self):
         obj = MockSerializable(var1=self.TEST_BOOL)

--- a/tests/sources/common/doctest_case_test.py
+++ b/tests/sources/common/doctest_case_test.py
@@ -1,3 +1,4 @@
+from client import exceptions as ex
 from client.sources.common import doctest_case
 import mock
 import textwrap
@@ -129,7 +130,8 @@ class DoctestCaseTest(unittest.TestCase):
             self.fail()
 
     def testConstructor_missingCode(self):
-        self.assertRaises(TypeError, doctest_case.DoctestCase, self.console)
+        self.assertRaises(ex.SerializeException, doctest_case.DoctestCase,
+                          self.console)
 
     def testConstructor_setupAndTeardown(self):
         try:

--- a/tests/sources/doctest/models_test.py
+++ b/tests/sources/doctest/models_test.py
@@ -74,7 +74,11 @@ class DoctestTest(unittest.TestCase):
         >>> 1 + 3
         4
         """, self.FILE)
-        self.assertTrue(test.run())
+        self.assertEqual({
+            'passed': 1,
+            'failed': 0,
+            'locked': 0,
+        }, test.run())
 
     def testRun_partialFail(self):
         test = self.makeDoctest("""
@@ -83,7 +87,11 @@ class DoctestTest(unittest.TestCase):
         >>> 2 + 2
         5
         """, self.FILE)
-        self.assertFalse(test.run())
+        self.assertEqual({
+            'passed': 0,
+            'failed': 1,
+            'locked': 0,
+        }, test.run())
 
     def testRun_completeFail(self):
         test = self.makeDoctest("""
@@ -92,7 +100,11 @@ class DoctestTest(unittest.TestCase):
         >>> 2 + 2
         5
         """, self.FILE)
-        self.assertFalse(test.run())
+        self.assertEqual({
+            'passed': 0,
+            'failed': 1,
+            'locked': 0,
+        }, test.run())
 
     def testScore_completePass(self):
         test = self.makeDoctest("""
@@ -101,7 +113,7 @@ class DoctestTest(unittest.TestCase):
         >>> 1 + 3
         4
         """, self.FILE)
-        self.assertEqual(1, test.run())
+        self.assertEqual(1, test.score())
 
     def testScore_partialFail(self):
         test = self.makeDoctest("""
@@ -110,7 +122,7 @@ class DoctestTest(unittest.TestCase):
         >>> 2 + 2
         5
         """, self.FILE)
-        self.assertEqual(0, test.run())
+        self.assertEqual(0, test.score())
 
     def testScore_completeFail(self):
         test = self.makeDoctest("""
@@ -119,4 +131,4 @@ class DoctestTest(unittest.TestCase):
         >>> 2 + 2
         5
         """, self.FILE)
-        self.assertEqual(0, test.run())
+        self.assertEqual(0, test.score())

--- a/tests/sources/ok_test/concept_test.py
+++ b/tests/sources/ok_test/concept_test.py
@@ -1,3 +1,4 @@
+from client import exceptions as ex
 from client.sources.ok_test import concept
 import unittest
 
@@ -30,7 +31,7 @@ class ConceptSuiteTest(unittest.TestCase):
             self.fail()
 
     def testConstructor_missingQuestion(self):
-        self.assertRaises(TypeError, self.makeTest, [
+        self.assertRaises(ex.SerializeException, self.makeTest, [
                 {
                     'answer': 'Answer',
                 },
@@ -41,7 +42,7 @@ class ConceptSuiteTest(unittest.TestCase):
             ])
 
     def testConstructor_missingAnswer(self):
-        self.assertRaises(TypeError, self.makeTest, [
+        self.assertRaises(ex.SerializeException, self.makeTest, [
                 {
                     'question': 'Question 1',
                     'answer': 'Answer',

--- a/tests/sources/ok_test/doctest_test.py
+++ b/tests/sources/ok_test/doctest_test.py
@@ -1,3 +1,4 @@
+from client import exceptions as ex
 from client.sources.ok_test import doctest
 import unittest
 
@@ -77,16 +78,13 @@ class DoctestSuiteTest(unittest.TestCase):
         except TypeError:
             self.fail()
 
-    def testConstructor_badTestCase(self):
-        self.assertRaises(TypeError, self.makeSuite,
+    def testConstructor_improperlyFormattedTestCase(self):
+        self.assertRaises(ex.SerializeException, self.makeSuite,
             [
                 {
                     'foo': "Not a valid case",
                 },
-            ],
-            teardown="""
-            >>> assign = assign.teardown()
-            """)
+            ])
 
     def testRun_noCases(self):
         test = self.makeSuite([])

--- a/tests/sources/ok_test/models_test.py
+++ b/tests/sources/ok_test/models_test.py
@@ -1,3 +1,4 @@
+from client import exceptions as ex
 from client.sources.ok_test import models
 from client.sources.common import core
 import mock
@@ -98,7 +99,7 @@ class OkTest(unittest.TestCase):
         self.assertEqual(1, self.mockSuite2.call_count)
 
     def testConstructor_unknownSuiteType(self):
-        self.assertRaises(TypeError, self.makeTest, suites=[
+        self.assertRaises(ex.SerializeException, self.makeTest, suites=[
             {
                 'type': 'mock1',
                 'foo': 'bar'
@@ -110,7 +111,7 @@ class OkTest(unittest.TestCase):
         ])
 
     def testConstructor_improperlyFormattedSuite(self):
-        self.assertRaises(TypeError, self.makeTest, suites=[
+        self.assertRaises(ex.SerializeException, self.makeTest, suites=[
             {
                 'foo': 'bar'
             },


### PR DESCRIPTION
Changelog:

* OK now errors if no tests were able to be loaded. If a single test source is not able to be loaded (e.g. can't find `hw01.py`), but other tests can be loaded, no error occurs (although a debug message is printed). This is to accomodate labs, where a student might have downloaded `lab02.py` but not `lab02_extra.py`; OK shouldn't exit prematurely just because it can't find `lab02_extra.py`
* Fix/add tests and make exceptions more consistent/informative
* Fix some bugs introduced in v1.3.2
* Resolve #19 
* Allow http requests to be sent even if assignment fails to load or protocols fail to run to completion.