### PR TITLE
Allow all doctests in a file to be loaded

### DIFF
--- a/client/__init__.py
+++ b/client/__init__.py
@@ -1,4 +1,4 @@
-__version__ = 'v1.3.7'
+__version__ = 'v1.3.8'
 
 import os
 import sys

--- a/client/cli/common/assignment.py
+++ b/client/cli/common/assignment.py
@@ -96,7 +96,7 @@ class Assignment(core.Serializable):
                 test_name = file
                 if parameter:
                     test_name += ':' + parameter
-                self.test_map[test_name] = module.load(file, parameter, self.cmd_args)
+                self.test_map.update(module.load(file, parameter, self.cmd_args))
                 log.info('Loaded {}'.format(test_name))
 
         if not self.test_map:

--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -82,7 +82,7 @@ def parse_input():
     parser.add_argument('--timeout', type=int, default=10,
                         help="set the timeout duration for running tests")
 
-    # Information
+    # Debug information
     parser.add_argument('--version', action='store_true',
                         help="Prints the version number and quits")
     parser.add_argument('--tests', action='store_true',
@@ -90,7 +90,7 @@ def parse_input():
     parser.add_argument('--debug', action='store_true',
                         help="show debug statements")
 
-    # Server communication
+    # Server parameters
     parser.add_argument('--local', action='store_true',
                         help="disable any network activity")
     parser.add_argument('--server', type=str,
@@ -211,7 +211,7 @@ def main():
             os.fsync(fp)
 
         if len(msg_list) == 0:
-            print("Server submission successful")
+            print("Backup successful.")
     except KeyboardInterrupt:
         print("Quitting ok.")
 

--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -62,39 +62,45 @@ def parse_input():
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter)
+    # Protocol paramters
     parser.add_argument('-q', '--question', type=str, action='append',
                         help="focus on specific questions")
-    parser.add_argument('--server', type=str,
-                        default='ok-server.appspot.com',
-                        help="server address")
-    parser.add_argument('-t', '--tests', metavar='A', default='tests', type=str,
-                        help="partial name or path to test file or directory")
     parser.add_argument('-u', '--unlock', action='store_true',
                         help="unlock tests interactively")
-    parser.add_argument('-v', '--verbose', action='store_true',
-                        help="print more output")
-    parser.add_argument('--debug', action='store_true',
-                        help="show debug statements")
-    parser.add_argument('--insecure', action='store_true',
-                        help="uses http instead of https")
     parser.add_argument('-i', '--interactive', action='store_true',
                         help="toggle interactive mode")
-    parser.add_argument('-l', '--lock', action='store_true',
-                        help="partial path to directory to lock")
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        help="print more output")
     parser.add_argument('--submit', action='store_true',
                         help="wait for server response without timeout")
-    parser.add_argument('-a', '--authenticate', action='store_true',
-                        help="authenticate, ignoring previous authentication")
-    parser.add_argument('--local', action='store_true',
-                        help="disable any network activity")
-    parser.add_argument('--timeout', type=int, default=10,
-                        help="set the timeout duration for running tests")
-    parser.add_argument('--version', action='store_true',
-                        help="Prints the version number and quits")
+    parser.add_argument('--lock', action='store_true',
+                        help="partial path to directory to lock")
     parser.add_argument('--score', action='store_true',
                         help="Scores the assignment")
     parser.add_argument('--config', type=str,
                         help="Specify a configuration file")
+    parser.add_argument('--timeout', type=int, default=10,
+                        help="set the timeout duration for running tests")
+
+    # Information
+    parser.add_argument('--version', action='store_true',
+                        help="Prints the version number and quits")
+    parser.add_argument('--tests', action='store_true',
+                        help="display a list of all available tests")
+    parser.add_argument('--debug', action='store_true',
+                        help="show debug statements")
+
+    # Server communication
+    parser.add_argument('--local', action='store_true',
+                        help="disable any network activity")
+    parser.add_argument('--server', type=str,
+                        default='ok-server.appspot.com',
+                        help="server address")
+    parser.add_argument('--authenticate', action='store_true',
+                        help="authenticate, ignoring previous authentication")
+    parser.add_argument('--insecure', action='store_true',
+                        help="uses http instead of https")
+
     return parser.parse_args()
 
 def main():
@@ -107,14 +113,6 @@ def main():
     if args.version:
         print("okpy=={}".format(client.__version__))
         exit(0)
-
-    # Check if ssl is available
-    if not args.local and not args.insecure:
-        try:
-            import ssl
-        except:
-            log.warning('Error importing ssl', stack_info=True)
-            sys.exit("SSL Bindings are not installed. You can install python3 SSL bindings or \nrun ok locally with python3 ok --local")
 
     # Instantiating assignment
     try:
@@ -142,6 +140,12 @@ def main():
         # Load tests and protocols
         assign.load()
 
+        if args.tests:
+            print('Available tests:')
+            for name in assign.test_map:
+                print('    ' + name)
+            exit(0)
+
         # Run protocol.on_start
         start_messages = dict()
         for name, proto in assign.protocol_map.items():
@@ -168,36 +172,46 @@ def main():
     else:
         assign.dump_tests()
 
+    if args.local:
+        return
+
     # Send request to server
     try:
         # TODO(denero) Print server responses.
-        if not args.local:
 
+        # Check if ssl is available
+        if not args.insecure:
             try:
-                access_token = auth.authenticate(args.authenticate)
-                log.info('Authenticated with access token %s', access_token)
+                import ssl
+            except:
+                log.warning('Error importing ssl', stack_info=True)
+                sys.exit("SSL Bindings are not installed. You can install python3 SSL bindings or \nrun ok locally with python3 ok --local")
 
-                print("Backing up your work...")
-                response = network.dump_to_server(access_token, msg_list,
-                                   assign.endpoint, args.server, args.insecure,
-                                   client.__version__, log, send_all=args.submit)
+        try:
+            access_token = auth.authenticate(args.authenticate)
+            log.info('Authenticated with access token %s', access_token)
 
-                if response:
-                    # Hardcode course id- we need to return it from the server at some point...
-                    print("Back-up successful: https://ok-server.appspot.com/#/5165212546105344/submission/{0}".format(response['data']['key']))
+            print("Backing up your work...")
+            response = network.dump_to_server(access_token, msg_list,
+                               assign.endpoint, args.server, args.insecure,
+                               client.__version__, log, send_all=args.submit)
 
-            except error.URLError as e:
-                log.warning('on_start messages not sent to server: %s', str(e))
+            if response:
+                # Hardcode course id- we need to return it from the server at some point...
+                print("Back-up successful: https://ok-server.appspot.com/#/5165212546105344/submission/{0}".format(response['data']['key']))
 
-            with open(BACKUP_FILE, 'wb') as fp:
-                log.info('Save %d unsent messages to %s', len(msg_list),
-                         BACKUP_FILE)
+        except error.URLError as e:
+            log.warning('on_start messages not sent to server: %s', str(e))
 
-                pickle.dump(msg_list, fp)
-                os.fsync(fp)
+        with open(BACKUP_FILE, 'wb') as fp:
+            log.info('Save %d unsent messages to %s', len(msg_list),
+                     BACKUP_FILE)
 
-            if len(msg_list) == 0:
-                print("Server submission successful")
+            pickle.dump(msg_list, fp)
+            os.fsync(fp)
+
+        if len(msg_list) == 0:
+            print("Server submission successful")
     except KeyboardInterrupt:
         print("Quitting ok.")
 

--- a/tests/cli/common/assignment_test.py
+++ b/tests/cli/common/assignment_test.py
@@ -36,7 +36,12 @@ class AssignmentTest(unittest.TestCase):
         self.mockFindFiles = mock.Mock()
         self.mockImportModule = mock.Mock()
         self.mockTest = mock.Mock()
-        self.mockImportModule.return_value.load.return_value = self.mockTest
+
+        self.mockModule = mock.Mock()
+        self.mockModule.load.return_value = {
+            self.FILE1: self.mockTest
+        }
+        self.mockImportModule.return_value = self.mockModule
 
     def makeAssignment(self, tests=None, protocols=None):
         if tests is None:
@@ -90,12 +95,16 @@ class AssignmentTest(unittest.TestCase):
         )))
 
         self.assertEqual(collections.OrderedDict((
-            (self.FILE1 + ':' + self.PARAMETER, self.mockTest),
+            (self.FILE1, self.mockTest),
         )), assign.test_map)
 
     def testConstructor_specifiedTest_ambiguousTest(self):
         self.cmd_args.question = [self.AMBIGUOUS_QUESTION]
         self.mockFindFiles.return_value = self.FILES
+        self.mockModule.load.return_value = collections.OrderedDict((
+            (self.FILE1, self.mockTest),
+            (self.FILE2, self.mockTest)
+        ))
         self.assertRaises(ex.LoadingException, self.makeAssignment)
 
     def testConstructor_specifiedTest_invalidTest(self):
@@ -106,6 +115,10 @@ class AssignmentTest(unittest.TestCase):
     def testConstructor_specifiedTest_match(self):
         self.cmd_args.question = [self.QUESTION1]
         self.mockFindFiles.return_value = self.FILES
+        self.mockModule.load.return_value = collections.OrderedDict((
+            (self.FILE1, self.mockTest),
+            (self.FILE2, self.mockTest)
+        ))
         assign = self.makeAssignment()
 
         self.assertEqual(collections.OrderedDict((
@@ -117,6 +130,10 @@ class AssignmentTest(unittest.TestCase):
     def testConstructor_specifiedTest_multipleQuestions(self):
         self.cmd_args.question = [self.QUESTION1, self.QUESTION2]
         self.mockFindFiles.return_value = self.FILES
+        self.mockModule.load.return_value = collections.OrderedDict((
+            (self.FILE1, self.mockTest),
+            (self.FILE2, self.mockTest)
+        ))
         assign = self.makeAssignment()
 
         self.assertEqual(collections.OrderedDict((
@@ -128,6 +145,10 @@ class AssignmentTest(unittest.TestCase):
     def testConstructor_specifiedTest_noSpecifiedTests(self):
         self.cmd_args.question = []
         self.mockFindFiles.return_value = self.FILES
+        self.mockModule.load.return_value = collections.OrderedDict((
+            (self.FILE1, self.mockTest),
+            (self.FILE2, self.mockTest)
+        ))
         assign = self.makeAssignment()
 
         self.assertEqual(collections.OrderedDict((
@@ -142,7 +163,9 @@ class AssignmentTest(unittest.TestCase):
                 raise ImportError
             else:
                 result = mock.Mock()
-                result.load.return_value = self.mockTest
+                result.load.return_value = {
+                    self.FILE1: self.mockTest
+                }
                 return result
         self.mockImportModule.side_effect = import_module
         self.mockFindFiles.return_value = [self.FILE1]
@@ -159,10 +182,13 @@ class AssignmentTest(unittest.TestCase):
 
     def testDumpTests(self):
         self.mockFindFiles.return_value = self.FILES
+        self.mockModule.load.return_value = collections.OrderedDict((
+            (self.FILE1, self.mockTest),
+            (self.FILE2, self.mockTest)
+        ))
         assign = self.makeAssignment()
 
         assign.dump_tests()
-        self.assertEqual(2, self.mockTest.dump.call_count)
         self.mockTest.dump.assert_has_calls([
             mock.call(self.FILE1),
             mock.call(self.FILE2)


### PR DESCRIPTION
The old config for doctest sources required each doctest to be specified explicitly:

    "hw1.py:square": "doctest",
    "hw1.py:double": "doctest"

This PR allows staff to simply specify the filename, and all the doctests in that file will be loaded:

    "hw1.py": "doctest"

Both formats are supported.