### PR TITLE
Matching

### DIFF
--- a/client/cli/common/assignment.py
+++ b/client/cli/common/assignment.py
@@ -121,10 +121,7 @@ class Assignment(core.Serializable):
 
     def _resolve_specified_tests(self):
         """For each of the questions specified on the command line,
-        find the best test corresponding that question.
-
-        The best match is found by finding the test filepath that has the
-        smallest edit distance with the specified question.
+        find the test corresponding that question.
 
         Questions are preserved in the order that they are specified on the
         command line. If no questions are specified, use the entire set of
@@ -138,27 +135,17 @@ class Assignment(core.Serializable):
             log.info('No tests loaded')
             return
         for question in self.cmd_args.question:
-            matches = []
-            for test in self.test_map:
-                if _has_subsequence(test.lower(), question.lower()):
-                    matches.append(test)
-
-            if len(matches) > 1:
-                print('Did you mean one of the following?')
-                for test in matches:
-                    print('    {}'.format(test))
-                raise ex.LoadingException('Ambiguous test specified: {}'.format(question))
-
-            elif not matches:
-                print('Did you mean one of the following?')
+            if question not in self.test_map:
+                print('Test "{}" not found.'.format(question))
+                print('Did you mean one of the following? '
+                      '(Names are case sensitive)')
                 for test in self.test_map:
                     print('    {}'.format(test))
                 raise ex.LoadingException('Invalid test specified: {}'.format(question))
 
-            match = matches[0]
-            log.info('Matched {} to {}'.format(question, match))
-            if match not in self.specified_tests:
-                self.specified_tests.append(self.test_map[match])
+            log.info('Adding {} to specified tests'.format(question))
+            if question not in self.specified_tests:
+                self.specified_tests.append(self.test_map[question])
 
 
     def _load_protocols(self):

--- a/client/sources/doctest/__init__.py
+++ b/client/sources/doctest/__init__.py
@@ -41,7 +41,7 @@ def load(file, name, args):
         raise ex.LoadingException('Error importing file {}'.format(file))
 
     if name:
-        return {file + ':' + name: _load_test(file, module, name, args)}
+        return {name: _load_test(file, module, name, args)}
     else:
         return _load_tests(file, module, args)
 
@@ -50,7 +50,7 @@ def _load_tests(file, module, args):
     tests = {}
     for name in dir(module):
         if callable(getattr(module, name)):
-            tests[file + ':' + name] = _load_test(file, module, name, args)
+            tests[name] = _load_test(file, module, name, args)
     return tests
 
 def _load_test(file, module, name, args):

--- a/client/sources/ok_test/__init__.py
+++ b/client/sources/ok_test/__init__.py
@@ -23,13 +23,15 @@ def load(file, parameter, args):
     RETURNS:
     Test
     """
-    if not os.path.isfile(file) or not file.endswith('.py'):
+    filename, ext = os.path.splitext(file)
+    if not os.path.isfile(file) or ext != '.py':
         log.info('Cannot import {} as an OK test'.format(file))
         raise ex.LoadingException('Cannot import {} as an OK test'.format(file))
 
     test = importing.load_module(file).test
+    name = os.path.basename(filename)
     try:
-        return {file: models.OkTest(SUITES, args.verbose, args.interactive,
+        return {name: models.OkTest(SUITES, args.verbose, args.interactive,
                              args.timeout, **test)}
     except ex.SerializeException:
         raise ex.LoadingException('Cannot load OK test {}'.format(file))

--- a/tests/cli/common/assignment_test.py
+++ b/tests/cli/common/assignment_test.py
@@ -20,8 +20,8 @@ class AssignmentTest(unittest.TestCase):
     FILE1 = 'tests/q1.py'
     FILE2 = 'tests/q2.py'
     FILES = [FILE1, FILE2]
-    QUESTION1 = 'q1'
-    QUESTION2 = 'tests2'
+    QUESTION1 = FILE1
+    QUESTION2 = FILE2
     AMBIGUOUS_QUESTION = 'q'
     INVALID_QUESTION = 'x'
 


### PR DESCRIPTION
Resolves #42 by replacing subsequence matching of command line-specified questions with exact matching.

Different sources name tests differently:
* Doctest sources name the test the name of the function; e.g. if the function is called `square`, the name of the  tests is called `square`. This assumes that it is unlikely to test two files at the same time with functions that have the same names.
* OkTest sources name the test the basename of the file. For example, the file `tests/q00.py` will be named `q00`.