### PR TITLE
Add error message if server connection times out

### DIFF
--- a/client/utils/network.py
+++ b/client/utils/network.py
@@ -6,7 +6,7 @@ import time
 import datetime
 import socket
 
-TIMEOUT = 1000
+TIMEOUT = 500
 RETRY_LIMIT = 5
 
 def send_to_server(access_token, messages, name, server, version, log,

--- a/client/utils/network.py
+++ b/client/utils/network.py
@@ -6,7 +6,7 @@ import time
 import datetime
 import socket
 
-TIMEOUT = 500
+TIMEOUT = 1000
 RETRY_LIMIT = 5
 
 def send_to_server(access_token, messages, name, server, version, log,
@@ -55,6 +55,7 @@ def dump_to_server(access_token, msg_list, name, server, insecure, version, log,
     first_response = 1
     while msg_list:
         if not send_all and datetime.datetime.now() > stop_time:
+            print('Connection to server timed out after {} milliseconds'.format(TIMEOUT))
             return
         message = msg_list[-1]
         try:


### PR DESCRIPTION
Client now prints out the following if server connection times out:

```
Backing up your work...
Connection to server timed out after 1000 milliseconds
Unable to complete backup.
```

I also changed the `TIMEOUT` to 1000 milliseconds instead of 500 milliseconds.