### PR TITLE
Remove empty suites from ok_tests

### DIFF
--- a/client/sources/ok_test/concept.py
+++ b/client/sources/ok_test/concept.py
@@ -16,7 +16,6 @@ log = logging.getLogger(__name__)
 
 class ConceptSuite(ok_models.Suite):
     scored = core.Boolean(default=False)
-    cases = core.List()
 
     def post_instantiation(self):
         for i, case in enumerate(self.cases):

--- a/client/sources/ok_test/doctest.py
+++ b/client/sources/ok_test/doctest.py
@@ -8,8 +8,6 @@ import logging
 log = logging.getLogger(__name__)
 
 class DoctestSuite(models.Suite):
-
-    cases = core.List()
     setup = core.String(default='')
     teardown = core.String(default='')
 

--- a/client/sources/ok_test/models.py
+++ b/client/sources/ok_test/models.py
@@ -137,6 +137,9 @@ class OkTest(models.Test):
                     print(message + 'leaving unlocked')
                 elif case.locked == True:
                     print(message + 'already unlocked')
+            if not suite.cases:
+                self.suites.remove(suite)
+                print('* Suite {}: removing empty suite'.format(suite_num))
         print()
 
     def dump(self):
@@ -152,9 +155,9 @@ class OkTest(models.Test):
 class Suite(core.Serializable):
     type = core.String()
     scored = core.Boolean(default=True)
+    cases = core.List()
 
-    def __init__(self, verbose, interactive, timeout=None,
-                 **fields):
+    def __init__(self, verbose, interactive, timeout=None, **fields):
         super().__init__(**fields)
         self.verbose = verbose
         self.interactive = interactive

--- a/tests/sources/ok_test/models_test.py
+++ b/tests/sources/ok_test/models_test.py
@@ -245,6 +245,52 @@ class OkTest(unittest.TestCase):
         self.assertEqual(1, self.mockCase1.lock.call_count)
         self.assertEqual(0, self.mockCase2.lock.call_count)
 
+    def testLock_emptySuite(self):
+        self.mockSuite1.return_value.cases = []
+        test = self.makeTest(suites=[
+            {'type': 'mock1'},
+        ])
+
+        try:
+            test.lock(self.hash_fn)
+        except Exception as e:
+            self.fail(e)
+        self.assertEqual(0, len(test.suites))
+
+    def testLock_allCasesHidden(self):
+        self.mockCase1.locked = core.NoValue
+        self.mockCase1.hidden = True
+        test = self.makeTest(suites=[
+            {'type': 'mock1'},
+        ])
+
+        try:
+            test.lock(self.hash_fn)
+        except Exception as e:
+            self.fail(e)
+        self.assertEqual(0, len(self.mockSuite1.return_value.cases))
+        self.assertEqual(0, len(test.suites))
+
+    def testLock_someCasesHidden(self):
+        self.mockCase1.locked = core.NoValue
+        self.mockCase1.hidden = True
+        self.mockCase2.locked = core.NoValue
+        self.mockCase2.hidden = False
+        self.mockSuite1.return_value.cases = [
+            self.mockCase1,
+            self.mockCase2
+        ]
+        test = self.makeTest(suites=[
+            {'type': 'mock1'},
+        ])
+
+        try:
+            test.lock(self.hash_fn)
+        except Exception as e:
+            self.fail(e)
+        self.assertEqual(1, len(self.mockSuite1.return_value.cases))
+        self.assertEqual(1, len(test.suites))
+
     def testDump(self):
         # TODO(albert)
         pass


### PR DESCRIPTION
When locking tests, suites that are empty will be removed. This might arise if all the test cases in a suite are hidden -- all the hidden cases will be removed, leaving an empty suite. The empty suite will then be removed as well.

This is an alternative solution to #11 . This minimizes the number of fields staff members have to keep track of.

Resolves #11 .