### PR TITLE
Add --backup flag to cli

### DIFF
--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -74,7 +74,7 @@ def parse_input():
     parser.add_argument('--submit', action='store_true',
                         help="Submit assignment")
     parser.add_argument('--backup', action='store_true',
-                        help="Backupt assignment reliably")
+                        help="Backup assignment reliably")
     parser.add_argument('--lock', action='store_true',
                         help="partial path to directory to lock")
     parser.add_argument('--score', action='store_true',

--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -72,7 +72,9 @@ def parse_input():
     parser.add_argument('-v', '--verbose', action='store_true',
                         help="print more output")
     parser.add_argument('--submit', action='store_true',
-                        help="wait for server response without timeout")
+                        help="Submit assignment")
+    parser.add_argument('--backup', action='store_true',
+                        help="Backupt assignment reliably")
     parser.add_argument('--lock', action='store_true',
                         help="partial path to directory to lock")
     parser.add_argument('--score', action='store_true',
@@ -194,7 +196,8 @@ def main():
             print("Backing up your work...")
             response = network.dump_to_server(access_token, msg_list,
                                assign.endpoint, args.server, args.insecure,
-                               client.__version__, log, send_all=args.submit)
+                               client.__version__, log,
+                               send_all=args.submit or args.backup)
 
             if isinstance(response, dict):
                 print("Backup successful for user: {0}".format(response['data']['email']))

--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -201,8 +201,12 @@ def main():
 
             if isinstance(response, dict):
                 print("Backup successful for user: {0}".format(response['data']['email']))
-                if args.submit:
+                if args.submit or args.backup:
                     print("URL: https://ok-server.appspot.com/#/{0}/submission/{1}".format(response['data']['course'], response['data']['key']))
+                if args.backup:
+                    print('NOTE: this is only a backup. '
+                          'To submit your assignment, run ok with --submit.')
+
             else:
                 print('Unable to complete backup.')
                 log.warning('network.dump_to_server returned {}'.format(response))


### PR DESCRIPTION
Resolves #54 . `--backup` is functionally equivalent to `--submit` in that it offers reliable backups. The only difference is that the assignment is not marked as a submission.