### PR TITLE
Fix doctest parsing bug involving leading whitespace in output

### DIFF
--- a/client/sources/doctest/models.py
+++ b/client/sources/doctest/models.py
@@ -57,7 +57,7 @@ class Doctest(models.Test):
             elif prompt_on:
                 if not line.startswith(leading_space):
                     raise ex.SerializeException('Inconsistent tabs for doctest')
-                code.append(line.lstrip())
+                code.append(line[len(leading_space):])
         module = self.SETUP.format(importing.path_to_module_string(self.file))
         self.case = doctest_case.DoctestCase(self.console, module,
                                              code='\n'.join(code))


### PR DESCRIPTION
Previously, the following doctest would be parsed incorrectly:

    >>> print('1\\n  2')
    1
      2

The leading indentation on the "2" would be stripped. This PR fixes the issue by stripping only the leading whitespace common to all lines.