### PR TITLE
Fixed import so auth can be used through git submodules.

### DIFF
--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from client.utils.sanction import Client
+from .sanction import Client
 from urllib.parse import urlparse, parse_qs
 import http.server
 import pickle


### PR DESCRIPTION
I'm trying to use ok-client as a git submodule in the ok-scripts repo for authentication. When I would try to import auth, I get the following. 

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/moowiz/src/ok-scripts/ok_client/client/utils/auth.py", line 3, in <module>
    from client.utils.sanction import Client
ImportError: No module named 'client.utils.sanction'
```

Adding this relative import fixes this issue.