### PR TITLE
Fix print-then-return doctest bug

### DIFF
--- a/client/sources/common/doctest_case.py
+++ b/client/sources/common/doctest_case.py
@@ -199,7 +199,6 @@ class PythonConsole(interpreter.Console):
         except PythonConsoleException as e:
             actual = e.exception.__class__.__name__
         else:
-            print(list(output))
             if value is not None:
                 print(repr(value))
                 actual = (output + repr(value)).strip()

--- a/client/sources/common/doctest_case.py
+++ b/client/sources/common/doctest_case.py
@@ -199,9 +199,10 @@ class PythonConsole(interpreter.Console):
         except PythonConsoleException as e:
             actual = e.exception.__class__.__name__
         else:
+            print(list(output))
             if value is not None:
                 print(repr(value))
-                actual = (output + '\n' + repr(value)).strip()
+                actual = (output + repr(value)).strip()
             else:
                 actual = output.strip()
 

--- a/tests/sources/doctest/models_test.py
+++ b/tests/sources/doctest/models_test.py
@@ -75,6 +75,34 @@ class DoctestTest(unittest.TestCase):
             'locked': 0,
         }, test.run())
 
+    def testConstructor_printThenReturn(self):
+        test = self.makeDoctest("""
+        >>> def foo():
+        ...     print('hi')
+        ...     return 1
+        >>> foo()
+        hi
+        1
+        """)
+        self.assertEqual({
+            'passed': 1,
+            'failed': 0,
+            'locked': 0,
+        }, test.run())
+
+    def testConstructor_printNoEndCharThenReturn(self):
+        test = self.makeDoctest("""
+        >>> def foo():
+        ...     print('hi', end='')
+        ...     return 1
+        >>> foo()
+        hi1
+        """)
+        self.assertEqual({
+            'passed': 1,
+            'failed': 0,
+            'locked': 0,
+        }, test.run())
 
     def testConstructor_invalidIndentationInconsistencies(self):
         # TODO(albert): test not passing


### PR DESCRIPTION
Previously, there was a bug in doctest parsing for printed output:

    >>> def foo():
    ...     print('hi')
    ...     return 1
    >>> foo()
    hi
    1

This would cause an extra blank line to be inserted between the `hi` and the `1`. This is because printing always prints a newline by default, but the client code was adding another newline after that. The fix is to remove the added newline.