### PR TITLE
Add sqlite integration

### DIFF
--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -119,7 +119,7 @@ def main():
     # Instantiating assignment
     try:
         assign = assignment.load_config(args.config, args)
-    except ex.OkException as e:
+    except ex.LoadingException as e:
         log.warning('Assignment could not instantiate', exc_info=True)
         print('Error: ' + str(e).strip())
         exit(1)

--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -119,7 +119,7 @@ def main():
     # Instantiating assignment
     try:
         assign = assignment.load_config(args.config, args)
-    except (ex.LoadingException, ex.SerializeException) as e:
+    except ex.OkException as e:
         log.warning('Assignment could not instantiate', exc_info=True)
         print('Error: ' + str(e).strip())
         exit(1)
@@ -168,6 +168,9 @@ def main():
     except ex.LoadingException as e:
         log.warning('Assignment could not load', exc_info=True)
         print('Error loading assignment: ' + str(e))
+    except ex.OkException as e:
+        log.warning('General OK exception occurred', exc_info=True)
+        print('Error: ' + str(e))
     except KeyboardInterrupt:
         log.info('Quitting protocols')
         assign.dump_tests()

--- a/client/sources/common/interpreter.py
+++ b/client/sources/common/interpreter.py
@@ -157,7 +157,7 @@ class Console(object):
         if not self._interpret_lines(self._setup):
             return False
 
-        success = self._interpret_lines(self._code, compare=True)
+        success = self._interpret_lines(self._code)
         success &= self._interpret_lines(self._teardown)
         return success
 
@@ -184,7 +184,7 @@ class Console(object):
     # Interpretation utilities #
     ############################
 
-    def _interpret_lines(self, lines, compare=False):
+    def _interpret_lines(self, lines, quiet=False):
         """Interprets the set of lines.
 
         RETURNS:
@@ -200,7 +200,7 @@ class Console(object):
                     except ConsoleException:
                         return False
                     current = []
-                if line:
+                if line and not quiet:
                     print(line)
                 line = self._strip_prompt(line)
                 self.add_history(line)

--- a/client/sources/common/interpreter.py
+++ b/client/sources/common/interpreter.py
@@ -157,7 +157,7 @@ class Console(object):
         if not self._interpret_lines(self._setup):
             return False
 
-        success = self._interpret_lines(self._code)
+        success = self._interpret_lines(self._code, compare_all=True)
         success &= self._interpret_lines(self._teardown)
         return success
 
@@ -184,8 +184,14 @@ class Console(object):
     # Interpretation utilities #
     ############################
 
-    def _interpret_lines(self, lines, quiet=False):
+    def _interpret_lines(self, lines, quiet=False, compare_all=False):
         """Interprets the set of lines.
+
+        PARAMTERS:
+        lines       -- list of str; lines of code
+        quiet       -- bool; if True, do not print lines of output
+        compare_all -- bool; if True, check for no output for lines that are not
+                       followed by a CodeAnswer
 
         RETURNS:
         bool; True if successful, False otherwise.
@@ -196,7 +202,10 @@ class Console(object):
                 if current and (line.startswith(self.PS1) or not line):
                     # Previous prompt ends when PS1 or a blank line occurs
                     try:
-                        self.evaluate('\n'.join(current))
+                        if compare_all:
+                            self._compare('', '\n'.join(current))
+                        else:
+                            self.evaluate('\n'.join(current))
                     except ConsoleException:
                         return False
                     current = []

--- a/client/sources/ok_test/__init__.py
+++ b/client/sources/ok_test/__init__.py
@@ -1,9 +1,10 @@
 from client import exceptions as ex
+from client.sources.common import importing
 from client.sources.ok_test import concept
 from client.sources.ok_test import doctest
-from client.sources.ok_test import scheme
 from client.sources.ok_test import models
-from client.sources.common import importing
+from client.sources.ok_test import scheme
+from client.sources.ok_test import sqlite
 import logging
 import os
 
@@ -13,6 +14,7 @@ SUITES = {
     'doctest': doctest.DoctestSuite,
     'concept': concept.ConceptSuite,
     'scheme': scheme.SchemeSuite,
+    'sqlite': sqlite.SqliteSuite,
 }
 
 def load(file, parameter, args):

--- a/client/sources/ok_test/scheme.py
+++ b/client/sources/ok_test/scheme.py
@@ -51,7 +51,7 @@ class SchemeConsole(interpreter.Console):
     def evaluate(self, code):
         if not code.strip():
             # scheme.scheme_read can't handle empty strings.
-            return None, None
+            return None, ''
         log_id = output.new_log()
         try:
             exp = self.scheme.read_line(code)

--- a/client/sources/ok_test/scheme.py
+++ b/client/sources/ok_test/scheme.py
@@ -89,7 +89,7 @@ class SchemeConsole(interpreter.Console):
             sys.path.insert(0, 'scheme')
             self.scheme = importlib.import_module(self.MODULE)
         except ImportError as e:
-            raise e
+            raise exceptions.ProtocolException('Could not import scheme')
 
 class SchemeSuite(doctest.DoctestSuite):
     console_type = SchemeConsole

--- a/client/sources/ok_test/scheme.py
+++ b/client/sources/ok_test/scheme.py
@@ -26,19 +26,14 @@ class SchemeConsole(interpreter.Console):
     MODULE = 'scheme'
     _output_fn = str
 
-    def __init__(self, verbose, interactive, timeout=None):
-        """Loads the Scheme module from the current working directory
-        before calling the superclass constructor.
-        """
-        self._import_scheme()
-        super().__init__(verbose, interactive, timeout)
-
     def load(self, code, setup='', teardown=''):
         """Prepares a set of setup, test, and teardown code to be
         run in the console.
+
+        Loads the Scheme module before loading any code.
         """
-        super().load(code, setup, teardown)
         self._import_scheme()
+        super().load(code, setup, teardown)
         self._frame = self.scheme.create_global_frame()
 
     def interact(self):

--- a/client/sources/ok_test/sqlite.py
+++ b/client/sources/ok_test/sqlite.py
@@ -1,0 +1,118 @@
+"""Console for interpreting sqlite."""
+
+from client import exceptions
+from client.sources.common import interpreter
+from client.sources.ok_test import doctest
+from client.utils import timer
+import importlib
+
+class SqliteConsole(interpreter.Console):
+    PS1 = 'sqlite> '
+    PS2 = '   ...> '
+
+    MODULE = 'sqlite3'
+    _output_fn = str
+
+    def __init__(self, verbose, interactive, timeout=None):
+        """Loads the Scheme module from the current working directory
+        before calling the superclass constructor.
+        """
+        super().__init__(verbose, interactive, timeout)
+
+    def load(self, code, setup='', teardown=''):
+        """Prepares a set of setup, test, and teardown code to be
+        run in the console.
+        """
+        self.sqlite3 = self.import_sqlite()
+        super().load(code, setup, teardown)
+        self._conn = self.sqlite3.connect(':memory:', check_same_thread=False)
+
+    def interact(self):
+        """Opens up an interactive session with the current state of
+        the console.
+        """
+        # TODO(albert)
+
+    def evaluate(self, code):
+        if code.startswith('.'):
+            if not self.evaluate_dot(code):
+                raise interpreter.ConsoleException(None)
+            return
+        try:
+            cursor = timer.timed(self.timeout, self._conn.execute, (code,))
+        except exceptions.Timeout as e:
+            print('Error: evaluation exceeded {} seconds.'.format(e.timeout))
+            raise interpreter.ConsoleException(e)
+        except self.sqlite3.Error as e:
+            print('Error: {}'.format(e))
+            raise interpreter.ConsoleException(e, exception_type='Error')
+        else:
+            return cursor
+
+    def _compare(self, expected, code):
+        try:
+            cursor = self.evaluate(code)
+        except interpreter.ConsoleException as e:
+            actual = [e.exception_type]
+        else:
+            actual = self.format_rows(cursor)
+
+        if expected != 'Error':
+            expected = set(expected.split('\n'))
+        if expected != actual:
+            print()
+            print('# Error: expected')
+            print('\n'.join('#     {}'.format(line)
+                            for line in expected))
+            print('# but got')
+            print('\n'.join('#     {}'.format(line)
+                            for line in actual))
+            raise interpreter.ConsoleException
+
+    def import_sqlite(self):
+        try:
+            sqlite = importlib.import_module(self.MODULE)
+        except ImportError:
+            print('Could not import sqlite3. Make sure you have installed sqlite3')
+            raise e
+        # TODO(albert): check version
+        return sqlite
+
+    def format_rows(self, cursor):
+        """Print rows from the given sqlite cursor, formatted with pipes "|".
+
+        RETURNS:
+        set; set of rows (formatted as strings with pipes "|" to delimit columns)
+        """
+        rows = set()
+        for row in cursor:
+            row = '|'.join(row)
+            rows.add(row)
+            print(row)
+        return rows
+
+    def evaluate_dot(self, code):
+        """Performs dot-command expansion on the given code.
+
+        PARAMETERS:
+        code -- str
+
+        RETURNS:
+        bool; True if the evaluation was successful.
+        """
+        if code.startswith('.read'):
+            return self._interpret_lines(self.evaluate_read(code), quiet=True)
+
+    def evaluate_read(self, line):
+        """Subroutine for evaluating a .read command."""
+        filename = line.replace('.read', '').strip()
+        if ' ' in filename:
+            # TODO(albert): handle invalid usage
+            pass
+        with open(filename, 'r') as f:
+            # TODO(albert): handle non-existent file
+            return f.read().split('\n')
+
+class SqliteSuite(doctest.DoctestSuite):
+    console_type = SqliteConsole
+

--- a/client/sources/ok_test/sqlite.py
+++ b/client/sources/ok_test/sqlite.py
@@ -13,17 +13,12 @@ class SqliteConsole(interpreter.Console):
 
     MODULE = 'sqlite3'
     VERSION = (3, 8, 3)
-    _output_fn = str
-
-    def __init__(self, verbose, interactive, timeout=None):
-        """Loads the Scheme module from the current working directory
-        before calling the superclass constructor.
-        """
-        super().__init__(verbose, interactive, timeout)
 
     def load(self, code, setup='', teardown=''):
         """Prepares a set of setup, test, and teardown code to be
         run in the console.
+
+        Loads the sqlite3 module before loading any code.
         """
         self.sqlite3 = self._import_sqlite()
         super().load(code, setup, teardown)

--- a/demo/scheme/tests/q1.py
+++ b/demo/scheme/tests/q1.py
@@ -33,6 +33,8 @@ test = {
           scm> (double 4)
           8
           # explanation: doubling a negative number
+          scm> (define x 4)
+          x
           """,
           'hidden': False
         }

--- a/demo/sqlite/config.ok
+++ b/demo/sqlite/config.ok
@@ -1,0 +1,17 @@
+{
+    "name": "Homework 1",
+    "endpoint": "https://okpy.org/path/to/endpoint",
+    "src": [
+        "hw1.sql"
+    ],
+    "tests": {
+        "tests/[!_]*.py": "ok_test"
+    },
+    "protocols": [
+        "file_contents",
+        "unlock",
+        "grading",
+        "scoring",
+        "analytics"
+    ]
+}

--- a/demo/sqlite/hw1.sql
+++ b/demo/sqlite/hw1.sql
@@ -1,0 +1,5 @@
+create table colors as
+  select 'red'    as color, 'primary' as type union
+  select 'blue'           , 'primary'         union
+  select 'green'          , 'secondary'       union
+  select 'yellow'         , 'primary';

--- a/demo/sqlite/tests/q1.py
+++ b/demo/sqlite/tests/q1.py
@@ -1,0 +1,32 @@
+test = {
+  'name': 'Question 1',
+  'points': 2,
+  'suites': [
+    {
+      'type': 'sqlite',
+      'setup': r"""
+      sqlite> .read hw1.sql
+      """,
+      'cases': [
+        {
+          'code': r"""
+          sqlite> select * from colors
+          red|primary
+          blue|primary
+          green|secondary
+          yellow|primary
+          """,
+        },
+        {
+          'code': r"""
+          sqlite> select color from colors
+          red
+          blue
+          green
+          yellow
+          """,
+        },
+      ],
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds an OK-style test for sqlite. OK will check that the installed version of sqlite3 is 3.8.3 or higher (this version includes the `with` statement).

Output for sqlite tests is **not** in sorted order. For example,

```
sqlite> select * from colors;
red
yellow
blue
```

Valid output could also be in the order `red, blue, yellow`, since the sqlite database does not enforce any particular order when doing `SELECT` statements. Accordingly, OK will first convert all actual and expected output into sets, and then compare the sets.

Currently, the only dot-command that is supported is `.read`.