### PR TITLE
Add What-would-Python-print test case

### DIFF
--- a/client/__init__.py
+++ b/client/__init__.py
@@ -1,4 +1,4 @@
-__version__ = 'v1.3.29'
+__version__ = 'v1.3.30'
 
 import os
 import sys

--- a/client/sources/ok_test/__init__.py
+++ b/client/sources/ok_test/__init__.py
@@ -5,6 +5,7 @@ from client.sources.ok_test import doctest
 from client.sources.ok_test import models
 from client.sources.ok_test import scheme
 from client.sources.ok_test import sqlite
+from client.sources.ok_test import wwpp
 import logging
 import os
 
@@ -15,6 +16,7 @@ SUITES = {
     'concept': concept.ConceptSuite,
     'scheme': scheme.SchemeSuite,
     'sqlite': sqlite.SqliteSuite,
+    'wwpp': wwpp.WwppSuite,
 }
 
 def load(file, parameter, args):

--- a/client/sources/ok_test/models.py
+++ b/client/sources/ok_test/models.py
@@ -147,7 +147,7 @@ class OkTest(models.Test):
         # directory may be left in a corrupted state.
         # TODO(albert): might need to delete obsolete test files too.
         json = format.prettyjson(self.to_json())
-        with open(self.file, 'w', encodings='utf-8') as f:
+        with open(self.file, 'w', encoding='utf-8') as f:
             f.write('test = ' + json)
 
 

--- a/client/sources/ok_test/wwpp.py
+++ b/client/sources/ok_test/wwpp.py
@@ -63,3 +63,8 @@ class WwppCase(interpreter.CodeCase):
                 print('\n'.join(line.output))
         return True
 
+    def unlock(self, interact):
+        print('What would Python print? If you get stuck, try it out in the '
+              'Python\ninterpreter!')
+        super().unlock(interact)
+

--- a/client/sources/ok_test/wwpp.py
+++ b/client/sources/ok_test/wwpp.py
@@ -1,0 +1,65 @@
+"""Case for What-would-Python-print tests."""
+
+from client import exceptions as ex
+from client.sources.common import core
+from client.sources.common import interpreter
+from client.sources.common import pyconsole
+from client.sources.ok_test import models
+import logging
+
+log = logging.getLogger(__name__)
+
+class WwppSuite(models.Suite):
+    scored = core.Boolean(default=False)
+
+    console_type = pyconsole.PythonConsole
+
+    def __init__(self, verbose, interactive, timeout=None, **fields):
+        super().__init__(verbose, interactive, timeout, **fields)
+        self.console = self.console_type(verbose, interactive, timeout)
+
+    def post_instantiation(self):
+        for i, case in enumerate(self.cases):
+            if not isinstance(case, dict):
+                raise ex.SerializeException('Test cases must be dictionaries')
+            self.cases[i] = WwppCase(self.console, **case)
+
+    def run(self, test_name, suite_number):
+        results = {
+            'passed': 0,
+            'failed': 0,
+            'locked': 0,
+        }
+        for i, case in enumerate(self.cases):
+            if case.locked == True or results['locked'] > 0:
+                # If a test case is locked, refuse to run any of the subsequent
+                # test cases
+                log.info('Case {} is locked'.format(i))
+                results['locked'] += 1
+                continue
+
+            success, output_log = self._run_case(test_name, suite_number,
+                                                 case, i + 1)
+            assert success, 'Wwpp case should never fail while grading'
+            results['passed'] += 1
+
+            if self.verbose:
+                print(''.join(output_log))
+        return results
+
+class WwppCase(interpreter.CodeCase):
+
+    def run(self):
+        """Runs the What-would-Python-print test case.
+
+        RETURNS:
+        bool; True if the test case passes, False otherwise.
+        """
+        for line in self.lines:
+            if isinstance(line, str) and line:
+                print(line)
+            elif isinstance(line, interpreter.CodeAnswer):
+                assert not line.locked, 'WwppCase should be unlocked in run'
+                print('\n'.join(line.output))
+        return True
+

--- a/demo/ok_test/tests/q1.py
+++ b/demo/ok_test/tests/q1.py
@@ -3,6 +3,7 @@ test = {
   'points': 3,
   'suites': [
     {
+      'type': 'concept',
       'cases': [
         {
           'question': 'What is the domain and range of the square function?',
@@ -15,7 +16,26 @@ test = {
           ],
         }
       ],
-      'type': 'concept'
+    },
+    {
+      'type': 'wwpp',
+      'cases': [
+        {
+          'code': r"""
+          >>> square(3)
+          9
+          >>> square(5)
+          25
+          """
+        },
+        {
+          'code': r"""
+          >>> print(print(square(4)))
+          16
+          None
+          """
+        }
+      ],
     },
     {
       'type': 'doctest',


### PR DESCRIPTION
Adds a WwppSuite and a corresponding WwppCase. The test structure is similar to that of a DoctestCase:

    {
      'type': 'wwpp',
      'cases': [
        {
          'code': r"""
          >>> square(3)
          9
          >>> square(5)
          25
          """
        },
        {
          'code': r"""
          >>> print(print(square(4)))
          16
          None
          """
        }
      ],
    },

You can test it out by doing the following:

```
cd demo/ok_test
ok-lock
ok -u
```

The second and third questions are WWPP unlocking questions. **Please do not commit locked tests.**

TODOs:

* [ ] Figure out what structure the WwppCase should send data. @soumyabasu , since you're meeting with Kristin to determine this, I'll leave it untouched for now.