### PR TITLE
Change partner labeling to strings instead of ints

### DIFF
--- a/client/protocols/scoring.py
+++ b/client/protocols/scoring.py
@@ -12,8 +12,10 @@ import logging
 log = logging.getLogger(__name__)
 
 #####################
-# Testing Mechanism #
+# Scoring Mechanism #
 #####################
+
+NO_PARTNER_NAME = 'Total'
 
 class ScoringProtocol(protocol_models.Protocol):
     """A Protocol that runs tests, formats results, and reports a student's
@@ -26,15 +28,12 @@ class ScoringProtocol(protocol_models.Protocol):
         to a partner. If test.partner is omitted (i.e. core.NoValue), the score
         for that test is added to every partner's score.
 
-        RETURNS
-        dict; mapping of partner (int) -> finalized scores (float).
-
         If there are no tests, the mapping will only contain one entry, mapping
-        (partner) 0 -> 0 (total score).
+        "Total" -> 0 (total score).
 
         If there are no partners specified by the tests, the mapping will only
-        contain one entry, mapping (partner) 0 -> total score (float). This
-        assumes there is always at least one partner.
+        contain one entry, mapping "Total" (partner) -> total score (float).
+        This assumes there is always at least one partner.
         """
         if self.args.export or not self.args.score:
             return
@@ -58,7 +57,7 @@ def display_breakdown(scores):
     """Prints the point breakdown given a dictionary of scores.
 
     RETURNS:
-    dict; maps partner (int) -> finalized score (float)
+    dict; maps partner (str) -> finalized score (float)
     """
     partner_totals = {}
 
@@ -74,10 +73,9 @@ def display_breakdown(scores):
         del partner_totals[None]
 
     finalized_scores = {}
-    print('Score')
+    print('Score:')
     if len(partner_totals) == 0:
-        # Add partner 0 as only partner.
-        partner_totals[0] = 0
+        partner_totals[NO_PARTNER_NAME] = 0
     for partner, score in sorted(partner_totals.items()):
         print('    Partner {}: {}'.format(partner, score + shared_points))
         finalized_scores[partner] = score + shared_points

--- a/client/protocols/scoring.py
+++ b/client/protocols/scoring.py
@@ -75,10 +75,12 @@ def display_breakdown(scores):
     finalized_scores = {}
     print('Score:')
     if len(partner_totals) == 0:
-        partner_totals[NO_PARTNER_NAME] = 0
-    for partner, score in sorted(partner_totals.items()):
-        print('    Partner {}: {}'.format(partner, score + shared_points))
-        finalized_scores[partner] = score + shared_points
+        print('    {}: {}'.format(NO_PARTNER_NAME, shared_points))
+        finalized_scores[NO_PARTNER_NAME] = shared_points
+    else:
+        for partner, score in sorted(partner_totals.items()):
+            print('    Partner {}: {}'.format(partner, score + shared_points))
+            finalized_scores[partner] = score + shared_points
     return finalized_scores
 
 protocol = ScoringProtocol

--- a/client/sources/common/models.py
+++ b/client/sources/common/models.py
@@ -5,7 +5,7 @@ from client.sources.common import core
 class Test(core.Serializable):
     name = core.String()
     points = core.Float()
-    partner = core.Int(optional=True)
+    partner = core.String(optional=True)
 
     def run(self):
         """Subclasses should override this method to run tests."""

--- a/tests/protocols/scoring_test.py
+++ b/tests/protocols/scoring_test.py
@@ -11,6 +11,9 @@ class ScoringProtocolTest(unittest.TestCase):
     SCORE1 = 2
     SCORE2 = 3
 
+    PARTNER1 = 'A'
+    PARTNER2 = 'B'
+
     def setUp(self):
         self.cmd_args = mock.Mock()
         self.cmd_args.score = True
@@ -47,31 +50,31 @@ class ScoringProtocolTest(unittest.TestCase):
     def testOnInteract_noTests(self):
         self.assignment.specified_tests = []
         self.assertEqual({
-            0: 0,
+            scoring.NO_PARTNER_NAME: 0,
         }, self.callRun())
 
     def testOnInteract_noSpecifiedPartners(self):
         messages = {}
         self.assertEqual({
-            0: self.SCORE0 + self.SCORE1 + self.SCORE2
+            scoring.NO_PARTNER_NAME: self.SCORE0 + self.SCORE1 + self.SCORE2
         }, self.callRun())
 
     def testOnInteract_specifiedPartners_noSharedPoints(self):
-        self.mockTest0.partner = 0
-        self.mockTest1.partner = 0
-        self.mockTest2.partner = 1
+        self.mockTest0.partner = self.PARTNER1
+        self.mockTest1.partner = self.PARTNER1
+        self.mockTest2.partner = self.PARTNER2
         messages = {}
         self.assertEqual({
-            0: self.SCORE0 + self.SCORE1,
-            1: self.SCORE2
+            self.PARTNER1: self.SCORE0 + self.SCORE1,
+            self.PARTNER2: self.SCORE2
         }, self.callRun())
 
     def testOnInteract_specifiedPartners_sharedPoints(self):
-        self.mockTest0.partner = 0
-        self.mockTest1.partner = 1
+        self.mockTest0.partner = self.PARTNER1
+        self.mockTest1.partner = self.PARTNER2
         messages = {}
         self.assertEqual({
-            0: self.SCORE0 + self.SCORE2,
-            1: self.SCORE1 + self.SCORE2
+            self.PARTNER1: self.SCORE0 + self.SCORE2,
+            self.PARTNER2: self.SCORE1 + self.SCORE2
         }, self.callRun())
 


### PR DESCRIPTION
Partners are now specified in OK test files as strings, not ints:

```
test = {
    ...
    'partner': 'A'
}
```

Test files with no 'partner' field specified will have their scores applied to all partners (this behavior was already present)

The output looks like this ("Partner " is prepended to each partner name):

```
Score:
    Partner A: 31.0
    Partner B: 31.0
```

Here's the output if an assignment has no partners:

```
Score:
    Total: 14.0
```