### PR TITLE
Prompt users for bcourses email instead of calnet id

### DIFF
--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -96,14 +96,14 @@ def authenticate(force=False):
         except Exception as _:
             print('Performing authentication')
 
-    print("Please enter your CalNet ID.")
-    calnet_id = input("CalNet ID: ")
+    print("Please enter your bCourses email (@berkeley.edu).")
+    email = input("bCourses email: ")
 
     c = Client(auth_endpoint='https://accounts.google.com/o/oauth2/auth',
                client_id=CLIENT_ID)
     url = c.auth_uri(scope="profile email", access_type='offline',
                      name='ok-server', redirect_uri=REDIRECT_URI,
-                     login_hint='%s@berkeley.edu' % (calnet_id))
+                     login_hint=email)
 
     webbrowser.open_new(url)
 


### PR DESCRIPTION
The prompt is changed to this:

```
Please enter your bCourses email (@berkeley.edu).
bCourses email: albert12132@berkeley.edu
```

@alvinwan , I'm not sure if this is implemented in #76 . I'm adding this for now because we need it as soon as possible (by 6/22). If you want to incorporate this into #76 before then, feel free to close this PR.

There's also the issue that some students' bCourses/bearfacts email is not a gmail-supported email address. This is especially an issue over the summer, where many students are concurrent enrollment/non-Berkeley students. Any thoughts on how to support this?