### PR TITLE
Record unlocking attempts

### DIFF
--- a/client/cli/common/assignment.py
+++ b/client/cli/common/assignment.py
@@ -100,7 +100,7 @@ class Assignment(core.Serializable):
                 test_name = file
                 if parameter:
                     test_name += ':' + parameter
-                self.test_map.update(module.load(file, parameter, self.cmd_args))
+                self.test_map.update(module.load(file, parameter, self))
                 log.info('Loaded {}'.format(test_name))
 
         if not self.test_map:

--- a/client/protocols/unlock.py
+++ b/client/protocols/unlock.py
@@ -33,8 +33,7 @@ class UnlockProtocol(models.Protocol):
     def __init__(self, cmd_args, assignment):
         super().__init__(cmd_args, assignment)
         self.hash_key = assignment.name
-        self.analytics = {}
-        self.current_test = None
+        self.analytics = []
 
     def run(self, messages):
         """Responsible for unlocking each test.
@@ -77,18 +76,22 @@ class UnlockProtocol(models.Protocol):
                 break
         messages['unlock'] = self.analytics
 
-    def interact(self, question_id, question, answer, choices=None, randomize=True):
+    def interact(self, unique_id, case_id, question_prompt, answer, choices=None, randomize=True):
         """Reads student input for unlocking tests until the student
         answers correctly.
 
         PARAMETERS:
-        question_id -- str; the ID that is recorded with this unlocking attempt.
-        question    -- str; the question prompt
-        answer      -- list; a list of locked lines in a test case answer.
-        choices     -- list or None; a list of choices. If None or an
-                       empty list, signifies the question is not multiple
-                       choice.
-        randomize   -- bool; if True, randomizes the choices on first invocation.
+        unique_id       -- str; the ID that is recorded with this unlocking
+                           attempt.
+        case_id         -- str; the ID that is recorded with this unlocking
+                           attempt.
+        question_prompt -- str; the question prompt
+        answer          -- list; a list of locked lines in a test case answer.
+        choices         -- list or None; a list of choices. If None or an
+                           empty list, signifies the question is not multiple
+                           choice.
+        randomize       -- bool; if True, randomizes the choices on first
+                           invocation.
 
         DESCRIPTION:
         Continually prompt the student for an answer to an unlocking
@@ -137,11 +140,12 @@ class UnlockProtocol(models.Protocol):
             else:
                 correct = True
 
-            self.analytics.setdefault(self.current_test, []).append({
-                'id': question_id,
+            self.analytics.append({
+                'id': unique_id,
+                'case_id': case_id,
                 'question timestamp': self.unix_time(question_timestamp),
                 'answer timestamp': self.unix_time(datetime.now()),
-                'question': question,
+                'prompt': question_prompt,
                 'answer': input_lines,
                 'correct': correct,
             })

--- a/client/protocols/unlock.py
+++ b/client/protocols/unlock.py
@@ -29,7 +29,6 @@ class UnlockProtocol(models.Protocol):
         'exit()',
         'quit()',
     )
-    TIMESTAMP_FORMAT = '%Y-%m-%d %H:%M:%S.%f'
 
     def __init__(self, cmd_args, assignment):
         super().__init__(cmd_args, assignment)
@@ -138,8 +137,8 @@ class UnlockProtocol(models.Protocol):
                 correct = True
 
             self.analytics.setdefault(self.current_test, []).append({
-                'question timestamp': question_timestamp.strftime(self.TIMESTAMP_FORMAT),
-                'answer timestamp': datetime.now().strftime(self.TIMESTAMP_FORMAT),
+                'question timestamp': self.unix_time(question_timestamp),
+                'answer timestamp': self.unix_time(datetime.now()),
                 'question': question,
                 'answer': input_lines,
                 'correct': correct,
@@ -186,5 +185,16 @@ class UnlockProtocol(models.Protocol):
         """
         if line and HAS_READLINE:
             readline.add_history(line)
+
+    def unix_time(self, dt):
+        """Returns the number of seconds since the UNIX epoch for the given
+        datetime (dt).
+
+        PARAMETERS:
+        dt -- datetime
+        """
+        epoch = datetime.utcfromtimestamp(0)
+        delta = dt - epoch
+        return delta.total_seconds()
 
 protocol = UnlockProtocol

--- a/client/protocols/unlock.py
+++ b/client/protocols/unlock.py
@@ -144,7 +144,6 @@ class UnlockProtocol(models.Protocol):
                 'question': question,
                 'answer': input_lines,
                 'correct': correct,
-                # TODO: add anonymized student ID
             })
 
             if not correct:
@@ -172,7 +171,6 @@ class UnlockProtocol(models.Protocol):
         """
         print("Choose the number of the correct choice:")
         choice_map = {}
-        # TODO(albert): consider using letters as choices instead of numbers.
         for i, choice in enumerate(choices):
             i = str(i)
             print('{}) {}'.format(i, format.indent(choice,

--- a/client/protocols/unlock.py
+++ b/client/protocols/unlock.py
@@ -77,17 +77,18 @@ class UnlockProtocol(models.Protocol):
                 break
         messages['unlock'] = self.analytics
 
-    def interact(self, question, answer, choices=None, randomize=True):
+    def interact(self, question_id, question, answer, choices=None, randomize=True):
         """Reads student input for unlocking tests until the student
         answers correctly.
 
         PARAMETERS:
-        question  -- str; the question prompt
-        answer    -- list; a list of locked lines in a test case answer.
-        choices   -- list or None; a list of choices. If None or an
-                     empty list, signifies the question is not multiple
-                     choice.
-        randomize -- bool; if True, randomizes the choices on first invocation.
+        question_id -- str; the ID that is recorded with this unlocking attempt.
+        question    -- str; the question prompt
+        answer      -- list; a list of locked lines in a test case answer.
+        choices     -- list or None; a list of choices. If None or an
+                       empty list, signifies the question is not multiple
+                       choice.
+        randomize   -- bool; if True, randomizes the choices on first invocation.
 
         DESCRIPTION:
         Continually prompt the student for an answer to an unlocking
@@ -137,6 +138,7 @@ class UnlockProtocol(models.Protocol):
                 correct = True
 
             self.analytics.setdefault(self.current_test, []).append({
+                'id': question_id,
                 'question timestamp': self.unix_time(question_timestamp),
                 'answer timestamp': self.unix_time(datetime.now()),
                 'question': question,
@@ -195,6 +197,6 @@ class UnlockProtocol(models.Protocol):
         """
         epoch = datetime.utcfromtimestamp(0)
         delta = dt - epoch
-        return delta.total_seconds()
+        return int(delta.total_seconds())
 
 protocol = UnlockProtocol

--- a/client/sources/common/interpreter.py
+++ b/client/sources/common/interpreter.py
@@ -60,17 +60,19 @@ class CodeCase(models.Case):
         self.locked = True
         self._sync_code()
 
-    def unlock(self, case_id, interact):
+    def unlock(self, unique_id_prefix, case_id, interact):
         """Unlocks the CodeCase.
 
         PARAMETERS:
-        case_id  -- string; an identifier for this Case, for purposes of
-                    analytics.
-        interact -- function; handles user interaction during the unlocking
-                    phase.
+        unique_id_prefix -- string; a prefix of a unique identifier for this
+                            Case, for purposes of analytics.
+        case_id          -- string; an identifier for this Case, for purposes of
+                            analytics.
+        interact         -- function; handles user interaction during the unlocking
+                            phase.
         """
         print(self.setup.strip())
-        part = 1
+        prompt_num = 1
         current_prompt = []
         try:
             for line in self.lines:
@@ -81,12 +83,15 @@ class CodeCase(models.Case):
                     if not line.locked:
                         print('\n'.join(line.output))
                         continue
-                    line.output = interact(case_id + ' >  Part {}'.format(part),
+
+                    unique_id = self._construct_unique_id(unique_id_prefix, self.lines)
+                    case_id = case_id + ' >  Prompt {}'.format(prompt_num)
+                    line.output = interact(unique_id, case_id,
                                            '\n'.join(current_prompt),
                                            line.output, line.choices)
                     line.locked = False
                     current_prompt = []
-                    part += 1
+                    prompt_num += 1
             self.locked = False
         finally:
             self._sync_code()
@@ -127,6 +132,19 @@ class CodeCase(models.Case):
             else:
                 new_code.append(line)
         self.code = '\n'.join(new_code)
+
+    def _construct_unique_id(self, id_prefix, lines):
+        """Constructs a unique ID for a particular prompt in this case,
+        based on the id_prefix and the lines in the prompt.
+        """
+        text = []
+        for line in lines:
+            if isinstance(line, str):
+                text.append(line)
+            elif isinstance(line, CodeAnswer):
+                text.append(line.dump())
+        return id_prefix + '\n' + '\n'.join(text)
+
 
 class Console(object):
     PS1 = '> '

--- a/client/sources/common/interpreter.py
+++ b/client/sources/common/interpreter.py
@@ -85,8 +85,8 @@ class CodeCase(models.Case):
                         continue
 
                     unique_id = self._construct_unique_id(unique_id_prefix, self.lines)
-                    case_id = case_id + ' >  Prompt {}'.format(prompt_num)
-                    line.output = interact(unique_id, case_id,
+                    line.output = interact(unique_id,
+                                           case_id + ' >  Prompt {}'.format(prompt_num),
                                            '\n'.join(current_prompt),
                                            line.output, line.choices)
                     line.locked = False

--- a/client/sources/common/interpreter.py
+++ b/client/sources/common/interpreter.py
@@ -68,15 +68,17 @@ class CodeCase(models.Case):
                     phase.
         """
         print(self.setup.strip())
+        previous_line = None
         try:
             for line in self.lines:
                 if isinstance(line, str) and line:
                     print(line)
+                    previous_line = line
                 elif isinstance(line, CodeAnswer):
                     if not line.locked:
                         print('\n'.join(line.output))
                         continue
-                    line.output = interact(line.output, line.choices)
+                    line.output = interact(previous_line, line.output, line.choices)
                     line.locked = False
             self.locked = False
         finally:

--- a/client/sources/common/interpreter.py
+++ b/client/sources/common/interpreter.py
@@ -68,18 +68,20 @@ class CodeCase(models.Case):
                     phase.
         """
         print(self.setup.strip())
-        previous_line = None
+        current_prompt = []
         try:
             for line in self.lines:
                 if isinstance(line, str) and line:
                     print(line)
-                    previous_line = line
+                    current_prompt.append(line)
                 elif isinstance(line, CodeAnswer):
                     if not line.locked:
                         print('\n'.join(line.output))
                         continue
-                    line.output = interact(previous_line, line.output, line.choices)
+                    line.output = interact('\n'.join(current_prompt),
+                                           line.output, line.choices)
                     line.locked = False
+                    current_prompt = []
             self.locked = False
         finally:
             self._sync_code()

--- a/client/sources/common/interpreter.py
+++ b/client/sources/common/interpreter.py
@@ -60,14 +60,17 @@ class CodeCase(models.Case):
         self.locked = True
         self._sync_code()
 
-    def unlock(self, interact):
+    def unlock(self, case_id, interact):
         """Unlocks the CodeCase.
 
         PARAMETERS:
+        case_id  -- string; an identifier for this Case, for purposes of
+                    analytics.
         interact -- function; handles user interaction during the unlocking
                     phase.
         """
         print(self.setup.strip())
+        part = 1
         current_prompt = []
         try:
             for line in self.lines:
@@ -78,10 +81,12 @@ class CodeCase(models.Case):
                     if not line.locked:
                         print('\n'.join(line.output))
                         continue
-                    line.output = interact('\n'.join(current_prompt),
+                    line.output = interact(case_id + ' >  Part {}'.format(part),
+                                           '\n'.join(current_prompt),
                                            line.output, line.choices)
                     line.locked = False
                     current_prompt = []
+                    part += 1
             self.locked = False
         finally:
             self._sync_code()

--- a/client/sources/common/models.py
+++ b/client/sources/common/models.py
@@ -51,17 +51,19 @@ class Case(core.Serializable):
         """
         raise NotImplementedError
 
-    def unlock(self, case_id, interact):
+    def unlock(self, unique_id_prefix, case_id, interact):
         """Subclasses should override this method for unlocking a test case.
 
         It is the responsibility of the the subclass to make any changes to the
         test case, including setting its locked field to False.
 
         PARAMETERS:
-        case_id  -- string; an identifier for this Case, for purposes of
-                    analytics.
-        interact -- function; handles user interaction during the unlocking
-                    phase.
+        unique_id_prefix -- string; an identifier for this Case, for purposes of
+                            analytics.
+        case_id          -- string; an identifier for this Case, for purposes of
+                            analytics.
+        interact         -- function; handles user interaction during the unlocking
+                            phase.
         """
         raise NotImplementedError
 

--- a/client/sources/common/models.py
+++ b/client/sources/common/models.py
@@ -51,13 +51,15 @@ class Case(core.Serializable):
         """
         raise NotImplementedError
 
-    def unlock(self, interact):
+    def unlock(self, case_id, interact):
         """Subclasses should override this method for unlocking a test case.
 
         It is the responsibility of the the subclass to make any changes to the
         test case, including setting its locked field to False.
 
         PARAMETERS:
+        case_id  -- string; an identifier for this Case, for purposes of
+                    analytics.
         interact -- function; handles user interaction during the unlocking
                     phase.
         """

--- a/client/sources/doctest/__init__.py
+++ b/client/sources/doctest/__init__.py
@@ -7,7 +7,7 @@ import traceback
 
 log = logging.getLogger(__name__)
 
-def load(file, name, args):
+def load(file, name, assign):
     """Loads doctests from a specified filepath.
 
     PARAMETERS:
@@ -40,19 +40,19 @@ def load(file, name, args):
         raise ex.LoadingException('Error importing file {}'.format(file))
 
     if name:
-        return {name: _load_test(file, module, name, args)}
+        return {name: _load_test(file, module, name, assign)}
     else:
-        return _load_tests(file, module, args)
+        return _load_tests(file, module, assign)
 
 
-def _load_tests(file, module, args):
+def _load_tests(file, module, assign):
     tests = {}
     for name in dir(module):
         if callable(getattr(module, name)):
-            tests[name] = _load_test(file, module, name, args)
+            tests[name] = _load_test(file, module, name, assign)
     return tests
 
-def _load_test(file, module, name, args):
+def _load_test(file, module, name, assign):
     if not hasattr(module, name):
         raise ex.LoadingException('Module {} has no function {}'.format(
                                   module.__name__, name))
@@ -62,8 +62,9 @@ def _load_test(file, module, name, args):
 
     docstring = func.__doc__ if func.__doc__ else ''
     try:
-        return models.Doctest(file, args.verbose, args.interactive, args.timeout,
-                              name=name, points=1, docstring=docstring)
+        return models.Doctest(file, assign.cmd_args.verbose, assign.cmd_args.interactive,
+                              assign.cmd_args.timeout, name=name, points=1,
+                              docstring=docstring)
     except ex.SerializeException:
         raise ex.LoadingException('Unable to load doctest for {} '
                                   'from {}'.format(name, file))

--- a/client/sources/ok_test/__init__.py
+++ b/client/sources/ok_test/__init__.py
@@ -19,7 +19,7 @@ SUITES = {
     'wwpp': wwpp.WwppSuite,
 }
 
-def load(file, parameter, args):
+def load(file, parameter, assign):
     """Loads an OK-style test from a specified filepath.
 
     PARAMETERS:
@@ -41,8 +41,10 @@ def load(file, parameter, args):
 
     name = os.path.basename(filename)
     try:
-        return {name: models.OkTest(file, SUITES, args.verbose, args.interactive,
-                             args.timeout, **test)}
+        return {name: models.OkTest(file, SUITES, assign.endpoint,
+                                    assign.cmd_args.verbose,
+                                    assign.cmd_args.interactive,
+                                    assign.cmd_args.timeout, **test)}
     except ex.SerializeException:
         raise ex.LoadingException('Cannot load OK test {}'.format(file))
 

--- a/client/sources/ok_test/concept.py
+++ b/client/sources/ok_test/concept.py
@@ -76,7 +76,7 @@ class ConceptCase(common_models.Case):
     def unlock(self, interact):
         """Unlocks the conceptual test case."""
         print('Q: ' + self.question)
-        answer = interact([self.answer], self.choices)
+        answer = interact(self.question, [self.answer], self.choices)
         assert len(answer) == 1
         answer = answer[0]
         if answer != self.answer:

--- a/client/sources/ok_test/concept.py
+++ b/client/sources/ok_test/concept.py
@@ -73,10 +73,10 @@ class ConceptCase(common_models.Case):
         self.answer = hash_fn(self.answer)
         self.locked = True
 
-    def unlock(self, interact):
+    def unlock(self, case_id, interact):
         """Unlocks the conceptual test case."""
         print('Q: ' + self.question)
-        answer = interact(self.question, [self.answer], self.choices)
+        answer = interact(case_id, self.question, [self.answer], self.choices)
         assert len(answer) == 1
         answer = answer[0]
         if answer != self.answer:

--- a/client/sources/ok_test/concept.py
+++ b/client/sources/ok_test/concept.py
@@ -73,10 +73,11 @@ class ConceptCase(common_models.Case):
         self.answer = hash_fn(self.answer)
         self.locked = True
 
-    def unlock(self, case_id, interact):
+    def unlock(self, unique_id_prefix, case_id, interact):
         """Unlocks the conceptual test case."""
         print('Q: ' + self.question)
-        answer = interact(case_id, self.question, [self.answer], self.choices)
+        answer = interact(unique_id_prefix + '\n' + self.question,
+                          case_id, self.question, [self.answer], self.choices)
         assert len(answer) == 1
         answer = answer[0]
         if answer != self.answer:

--- a/client/sources/ok_test/models.py
+++ b/client/sources/ok_test/models.py
@@ -100,9 +100,11 @@ class OkTest(models.Test):
                                 for case in suite.cases])
         for suite_num, suite in enumerate(self.suites):
             for case_num, case in enumerate(suite.cases):
+                case_id = '{} > Suite {} > Case {}'.format(
+                            self.name, suite_num + 1, case_num + 1)
+
                 format.print_line('-')
-                print('{} > Suite {} > Case {}'.format(self.name, suite_num + 1,
-                                                       case_num + 1))
+                print(case_id)
                 print('(cases remaining: {})'.format(total_cases))
                 print()
                 total_cases -= 1
@@ -112,7 +114,7 @@ class OkTest(models.Test):
                     print()
                     continue
 
-                case.unlock(interact)
+                case.unlock(case_id, interact)
 
         assert total_cases == 0, 'Number of cases is incorrect'
         format.print_line('-')

--- a/client/sources/ok_test/models.py
+++ b/client/sources/ok_test/models.py
@@ -12,13 +12,15 @@ class OkTest(models.Test):
     suites = core.List()
     description = core.String(optional=True)
 
-    def __init__(self, file, suite_map, verbose, interactive, timeout=None, **fields):
+    def __init__(self, file, suite_map, assign_name, verbose, interactive,
+                 timeout=None, **fields):
         super().__init__(**fields)
         self.file = file
         self.suite_map = suite_map
         self.verbose = verbose
         self.interactive = interactive
         self.timeout = timeout
+        self.assignment_name = assign_name
 
     def post_instantiation(self):
         for i, suite in enumerate(self.suites):
@@ -114,7 +116,7 @@ class OkTest(models.Test):
                     print()
                     continue
 
-                case.unlock(case_id, interact)
+                case.unlock(self.unique_id_prefix, case_id, interact)
 
         assert total_cases == 0, 'Number of cases is incorrect'
         format.print_line('-')
@@ -152,6 +154,9 @@ class OkTest(models.Test):
         with open(self.file, 'w', encoding='utf-8') as f:
             f.write('test = ' + json)
 
+    @property
+    def unique_id_prefix(self):
+        return self.assignment_name + '\n' + self.name
 
 class Suite(core.Serializable):
     type = core.String()

--- a/client/sources/ok_test/wwpp.py
+++ b/client/sources/ok_test/wwpp.py
@@ -63,8 +63,8 @@ class WwppCase(interpreter.CodeCase):
                 print('\n'.join(line.output))
         return True
 
-    def unlock(self, case_id, interact):
+    def unlock(self, unique_id_prefix, case_id, interact):
         print('What would Python print? If you get stuck, try it out in the '
               'Python\ninterpreter!')
-        super().unlock(case_id, interact)
+        super().unlock(unique_id_prefix, case_id, interact)
 

--- a/client/sources/ok_test/wwpp.py
+++ b/client/sources/ok_test/wwpp.py
@@ -63,8 +63,8 @@ class WwppCase(interpreter.CodeCase):
                 print('\n'.join(line.output))
         return True
 
-    def unlock(self, interact):
+    def unlock(self, case_id, interact):
         print('What would Python print? If you get stuck, try it out in the '
               'Python\ninterpreter!')
-        super().unlock(interact)
+        super().unlock(case_id, interact)
 

--- a/client/sources/scheme_test/__init__.py
+++ b/client/sources/scheme_test/__init__.py
@@ -2,7 +2,7 @@ from client import exceptions as ex
 from client.sources.scheme_test import models
 import os
 
-def load(file, _, args):
+def load(file, _, assign):
     """Loads Scheme tests from a specified filepath.
 
     PARAMETERS:
@@ -18,7 +18,7 @@ def load(file, _, args):
         file_contents = f.read()
 
     try:
-        return {file: models.SchemeTest(file, file_contents, args.timeout,
+        return {file: models.SchemeTest(file, file_contents, assign.cmd_args.timeout,
                                         name=file, points=1)}
     except ex.SerializeException:
         raise ex.LoadingException('Unable to load Scheme test '

--- a/tests/protocols/unlock_test.py
+++ b/tests/protocols/unlock_test.py
@@ -6,6 +6,8 @@ import mock
 import unittest
 
 class UnlockProtocolTest(unittest.TestCase):
+    TEST = 'Test 1'
+
     def setUp(self):
         self.cmd_args = mock.Mock()
         self.cmd_args.export = False
@@ -35,6 +37,8 @@ class UnlockProtocolTest(unittest.TestCase):
         self.assertIsInstance(messages['unlock'], dict)
 
 class InteractTest(unittest.TestCase):
+    TEST = 'Test 0'
+    QUESTION = 'Question 0'
     SHORT_ANSWER = ['42']
     LONG_ANSWER = ['3.1', '41', '59']
     INCORRECT_ANSWERS = ['a', 'b', 'c']
@@ -44,57 +48,126 @@ class InteractTest(unittest.TestCase):
         self.cmd_args = mock.Mock()
         self.assignment = mock.Mock()
         self.proto = unlock.protocol(self.cmd_args, self.assignment)
+        self.proto.current_test = self.TEST
+
         self.proto._verify = self.mockVerify
         self.proto._input = self.mockInput
 
         self.input_choices = []
+        self.choice_number = 0
 
     def mockInput(self, prompt):
-        return self.input_choices.pop(0)
+        self.choice_number += 1
+        return self.input_choices[self.choice_number - 1]
 
     def mockVerify(self, guess, locked):
         return guess == locked
 
+    def checkNumberOfAttempts(self, number_of_attempts):
+        self.assertIn(self.TEST, self.proto.analytics)
+        self.assertEqual(number_of_attempts, len(self.proto.analytics[self.TEST]))
+
+    def checkDictField(self, dictionary, field, expected_value):
+        self.assertIn(field, dictionary)
+        self.assertEqual(expected_value, dictionary[field])
+
     def testInputExitPattern(self):
         self.input_choices = [self.proto.EXIT_INPUTS[0]]
         self.assertRaises((KeyboardInterrupt, EOFError), self.proto.interact,
-                          self.SHORT_ANSWER)
+                          self.QUESTION, self.SHORT_ANSWER)
 
     def testRaiseError(self):
         self.proto._input = mock.Mock(side_effect=KeyboardInterrupt)
         self.assertRaises((KeyboardInterrupt, EOFError), self.proto.interact,
-                          self.SHORT_ANSWER)
+                          self.QUESTION, self.SHORT_ANSWER)
 
     def testSingleLine_immediatelyCorrect(self):
         self.input_choices = list(self.SHORT_ANSWER)
         self.assertEqual(self.SHORT_ANSWER,
-                         self.proto.interact(self.SHORT_ANSWER))
+                         self.proto.interact(self.QUESTION, self.SHORT_ANSWER))
+
+        self.checkNumberOfAttempts(1)
+        attempt = self.proto.analytics[self.TEST][0]
+
+        self.checkDictField(attempt, 'question', self.QUESTION)
+        self.checkDictField(attempt, 'answer', self.SHORT_ANSWER)
+        self.checkDictField(attempt, 'correct', True)
 
     def testSingleLine_multipleFailsBeforeSuccess(self):
         self.input_choices = self.INCORRECT_ANSWERS + self.SHORT_ANSWER
         self.assertEqual(self.SHORT_ANSWER,
-                         self.proto.interact(self.SHORT_ANSWER))
+                         self.proto.interact(self.QUESTION, self.SHORT_ANSWER))
+
+        self.checkNumberOfAttempts(1 + len(self.INCORRECT_ANSWERS))
+        for attempt_number, attempt in enumerate(self.proto.analytics[self.TEST]):
+            self.checkDictField(attempt, 'question', self.QUESTION)
+            if attempt_number < len(self.INCORRECT_ANSWERS):
+                self.checkDictField(attempt, 'answer', [self.INCORRECT_ANSWERS[attempt_number]])
+                self.checkDictField(attempt, 'correct', False)
+            else:
+                self.checkDictField(attempt, 'answer', self.SHORT_ANSWER)
+                self.checkDictField(attempt, 'correct', True)
 
     def testMultipleLine_immediatelyCorrect(self):
         self.input_choices = list(self.LONG_ANSWER)
         self.assertEqual(self.LONG_ANSWER,
-                         self.proto.interact(self.LONG_ANSWER))
+                         self.proto.interact(self.QUESTION, self.LONG_ANSWER))
+
+        self.checkNumberOfAttempts(1)
+        attempt = self.proto.analytics[self.TEST][0]
+
+        self.checkDictField(attempt, 'question', self.QUESTION)
+        self.checkDictField(attempt, 'answer', self.LONG_ANSWER)
+        self.checkDictField(attempt, 'correct', True)
 
     def testMultipleLine_multipleFailsBeforeSuccess(self):
-        self.input_choices = self.LONG_ANSWER[0:] + self.INCORRECT_ANSWERS + \
+        self.input_choices = self.LONG_ANSWER[:1] + self.INCORRECT_ANSWERS + \
                              self.LONG_ANSWER
         self.assertEqual(self.LONG_ANSWER,
-                         self.proto.interact(self.LONG_ANSWER))
+                         self.proto.interact(self.QUESTION, self.LONG_ANSWER))
+
+        print(self.proto.analytics[self.TEST])
+        self.checkNumberOfAttempts(1 + len(self.INCORRECT_ANSWERS))
+        for attempt_number, attempt in enumerate(self.proto.analytics[self.TEST]):
+            self.checkDictField(attempt, 'question', self.QUESTION)
+
+            if attempt_number == 0:
+                self.checkDictField(attempt, 'answer', [self.LONG_ANSWER[0], self.INCORRECT_ANSWERS[0]])
+                self.checkDictField(attempt, 'correct', False)
+            elif attempt_number < len(self.INCORRECT_ANSWERS):
+                self.checkDictField(attempt, 'answer', [self.INCORRECT_ANSWERS[attempt_number]])
+                self.checkDictField(attempt, 'correct', False)
+            else:
+                self.checkDictField(attempt, 'answer', self.LONG_ANSWER)
+                self.checkDictField(attempt, 'correct', True)
 
     def testMultipleChoice_immediatelyCorrect(self):
         self.input_choices = ['0']
         self.assertEqual(self.SHORT_ANSWER,
-                         self.proto.interact(self.SHORT_ANSWER, self.CHOICES,
+                         self.proto.interact(self.QUESTION, self.SHORT_ANSWER, self.CHOICES,
                                              randomize=False))
+
+        self.checkNumberOfAttempts(1)
+        attempt = self.proto.analytics[self.TEST][0]
+
+        self.checkDictField(attempt, 'question', self.QUESTION)
+        self.checkDictField(attempt, 'answer', self.SHORT_ANSWER)
+        self.checkDictField(attempt, 'correct', True)
 
     def testMultipleChoice_multipleFailsBeforeSuccess(self):
         self.input_choices = ['1', '2', '0']
         self.assertEqual(self.SHORT_ANSWER,
-                         self.proto.interact(self.SHORT_ANSWER, self.CHOICES,
-                                             randomize=False))
+                         self.proto.interact(self.QUESTION, self.SHORT_ANSWER,
+                                             self.CHOICES, randomize=False))
 
+        self.checkNumberOfAttempts(len(self.input_choices))
+        for attempt_number, attempt in enumerate(self.proto.analytics[self.TEST]):
+            self.checkDictField(attempt, 'question', self.QUESTION)
+            choice = self.input_choices[attempt_number]
+
+            if attempt_number < len(self.input_choices) - 1:
+                self.checkDictField(attempt, 'answer', [self.CHOICES[int(choice)]])
+                self.checkDictField(attempt, 'correct', False)
+            else:
+                self.checkDictField(attempt, 'answer', self.SHORT_ANSWER)
+                self.checkDictField(attempt, 'correct', True)

--- a/tests/protocols/unlock_test.py
+++ b/tests/protocols/unlock_test.py
@@ -38,6 +38,7 @@ class UnlockProtocolTest(unittest.TestCase):
 
 class InteractTest(unittest.TestCase):
     TEST = 'Test 0'
+    QUESTION_ID = TEST + ' > Suite 1 > Case 1'
     QUESTION = 'Question 0'
     SHORT_ANSWER = ['42']
     LONG_ANSWER = ['3.1', '41', '59']
@@ -74,17 +75,18 @@ class InteractTest(unittest.TestCase):
     def testInputExitPattern(self):
         self.input_choices = [self.proto.EXIT_INPUTS[0]]
         self.assertRaises((KeyboardInterrupt, EOFError), self.proto.interact,
-                          self.QUESTION, self.SHORT_ANSWER)
+                          self.QUESTION_ID, self.QUESTION, self.SHORT_ANSWER)
 
     def testRaiseError(self):
         self.proto._input = mock.Mock(side_effect=KeyboardInterrupt)
         self.assertRaises((KeyboardInterrupt, EOFError), self.proto.interact,
-                          self.QUESTION, self.SHORT_ANSWER)
+                          self.QUESTION_ID, self.QUESTION, self.SHORT_ANSWER)
 
     def testSingleLine_immediatelyCorrect(self):
         self.input_choices = list(self.SHORT_ANSWER)
         self.assertEqual(self.SHORT_ANSWER,
-                         self.proto.interact(self.QUESTION, self.SHORT_ANSWER))
+                         self.proto.interact(self.QUESTION_ID, self.QUESTION,
+                                             self.SHORT_ANSWER))
 
         self.checkNumberOfAttempts(1)
         attempt = self.proto.analytics[self.TEST][0]
@@ -96,7 +98,8 @@ class InteractTest(unittest.TestCase):
     def testSingleLine_multipleFailsBeforeSuccess(self):
         self.input_choices = self.INCORRECT_ANSWERS + self.SHORT_ANSWER
         self.assertEqual(self.SHORT_ANSWER,
-                         self.proto.interact(self.QUESTION, self.SHORT_ANSWER))
+                         self.proto.interact(self.QUESTION_ID, self.QUESTION,
+                                             self.SHORT_ANSWER))
 
         self.checkNumberOfAttempts(1 + len(self.INCORRECT_ANSWERS))
         for attempt_number, attempt in enumerate(self.proto.analytics[self.TEST]):
@@ -111,7 +114,8 @@ class InteractTest(unittest.TestCase):
     def testMultipleLine_immediatelyCorrect(self):
         self.input_choices = list(self.LONG_ANSWER)
         self.assertEqual(self.LONG_ANSWER,
-                         self.proto.interact(self.QUESTION, self.LONG_ANSWER))
+                         self.proto.interact(self.QUESTION_ID, self.QUESTION,
+                                             self.LONG_ANSWER))
 
         self.checkNumberOfAttempts(1)
         attempt = self.proto.analytics[self.TEST][0]
@@ -124,7 +128,8 @@ class InteractTest(unittest.TestCase):
         self.input_choices = self.LONG_ANSWER[:1] + self.INCORRECT_ANSWERS + \
                              self.LONG_ANSWER
         self.assertEqual(self.LONG_ANSWER,
-                         self.proto.interact(self.QUESTION, self.LONG_ANSWER))
+                         self.proto.interact(self.QUESTION_ID, self.QUESTION,
+                                             self.LONG_ANSWER))
 
         print(self.proto.analytics[self.TEST])
         self.checkNumberOfAttempts(1 + len(self.INCORRECT_ANSWERS))
@@ -144,7 +149,8 @@ class InteractTest(unittest.TestCase):
     def testMultipleChoice_immediatelyCorrect(self):
         self.input_choices = ['0']
         self.assertEqual(self.SHORT_ANSWER,
-                         self.proto.interact(self.QUESTION, self.SHORT_ANSWER, self.CHOICES,
+                         self.proto.interact(self.QUESTION_ID, self.QUESTION,
+                                             self.SHORT_ANSWER, self.CHOICES,
                                              randomize=False))
 
         self.checkNumberOfAttempts(1)
@@ -157,8 +163,9 @@ class InteractTest(unittest.TestCase):
     def testMultipleChoice_multipleFailsBeforeSuccess(self):
         self.input_choices = ['1', '2', '0']
         self.assertEqual(self.SHORT_ANSWER,
-                         self.proto.interact(self.QUESTION, self.SHORT_ANSWER,
-                                             self.CHOICES, randomize=False))
+                         self.proto.interact(self.QUESTION_ID, self.QUESTION,
+                                             self.SHORT_ANSWER, self.CHOICES,
+                                             randomize=False))
 
         self.checkNumberOfAttempts(len(self.input_choices))
         for attempt_number, attempt in enumerate(self.proto.analytics[self.TEST]):

--- a/tests/protocols/unlock_test.py
+++ b/tests/protocols/unlock_test.py
@@ -23,7 +23,7 @@ class UnlockProtocolTest(unittest.TestCase):
             self.fail('UnlockProtocol.run should abort gracefully')
 
         self.assertIn('unlock', messages)
-        self.assertIsInstance(messages['unlock'], dict)
+        self.assertIsInstance(messages['unlock'], list)
 
     def testOnInteract_withTests(self):
         self.assignment.specified_tests = [mock.Mock(spec=models.Test)]
@@ -34,12 +34,13 @@ class UnlockProtocolTest(unittest.TestCase):
             self.fail('UnlockProtocol.run should abort gracefully')
 
         self.assertIn('unlock', messages)
-        self.assertIsInstance(messages['unlock'], dict)
+        self.assertIsInstance(messages['unlock'], list)
 
 class InteractTest(unittest.TestCase):
     TEST = 'Test 0'
-    QUESTION_ID = TEST + ' > Suite 1 > Case 1'
-    QUESTION = 'Question 0'
+    CASE_ID = TEST + ' > Suite 1 > Case 1'
+    UNIQUE_ID = 'string containing\nunique id'
+    PROMPT = 'question prompt text'
     SHORT_ANSWER = ['42']
     LONG_ANSWER = ['3.1', '41', '59']
     INCORRECT_ANSWERS = ['a', 'b', 'c']
@@ -65,116 +66,140 @@ class InteractTest(unittest.TestCase):
         return guess == locked
 
     def checkNumberOfAttempts(self, number_of_attempts):
-        self.assertIn(self.TEST, self.proto.analytics)
-        self.assertEqual(number_of_attempts, len(self.proto.analytics[self.TEST]))
+        self.assertEqual(number_of_attempts, len(self.proto.analytics))
 
     def checkDictField(self, dictionary, field, expected_value):
         self.assertIn(field, dictionary)
         self.assertEqual(expected_value, dictionary[field])
 
+    def callsInteractError(self, expected_error, answer, choices=None, unique_id=None,
+            case_id=None, prompt=None, randomize=True):
+        if not unique_id:
+            unique_id = self.UNIQUE_ID
+        if not case_id:
+            case_id = self.CASE_ID
+        if not prompt:
+            prompt = self.PROMPT
+        if not choices:
+            choices = None
+
+        self.assertRaises(expected_error, self.proto.interact,
+                          unique_id, case_id, prompt, answer)
+
+    def callsInteract(self, expected, answer, choices=None, unique_id=None,
+                case_id=None, prompt=None, randomize=True):
+        if not unique_id:
+            unique_id = self.UNIQUE_ID
+        if not case_id:
+            case_id = self.CASE_ID
+        if not prompt:
+            prompt = self.PROMPT
+        if not choices:
+            choices = None
+
+        self.assertEqual(expected, self.proto.interact(unique_id, case_id,
+                         prompt, answer, choices=choices, randomize=randomize))
+
+    def validateRecord(self, record, answer, correct, prompt=None,
+                       unique_id=None, case_id=None):
+        if not unique_id:
+            unique_id = self.UNIQUE_ID
+        if not case_id:
+            case_id = self.CASE_ID
+        if not prompt:
+            prompt = self.PROMPT
+
+        self.checkDictField(record, 'prompt', prompt)
+        self.checkDictField(record, 'answer', answer)
+        self.checkDictField(record, 'correct', correct)
+        self.checkDictField(record, 'id', unique_id)
+        self.checkDictField(record, 'case_id', case_id)
+
+        self.assertIn('question timestamp', record)
+        self.assertIsInstance(record['question timestamp'], int)
+
+        self.assertIn('answer timestamp', record)
+        self.assertIsInstance(record['answer timestamp'], int)
+
     def testInputExitPattern(self):
         self.input_choices = [self.proto.EXIT_INPUTS[0]]
-        self.assertRaises((KeyboardInterrupt, EOFError), self.proto.interact,
-                          self.QUESTION_ID, self.QUESTION, self.SHORT_ANSWER)
+        self.callsInteractError((KeyboardInterrupt, EOFError), self.SHORT_ANSWER)
 
     def testRaiseError(self):
         self.proto._input = mock.Mock(side_effect=KeyboardInterrupt)
-        self.assertRaises((KeyboardInterrupt, EOFError), self.proto.interact,
-                          self.QUESTION_ID, self.QUESTION, self.SHORT_ANSWER)
+        self.callsInteractError((KeyboardInterrupt, EOFError), self.SHORT_ANSWER)
 
     def testSingleLine_immediatelyCorrect(self):
         self.input_choices = list(self.SHORT_ANSWER)
-        self.assertEqual(self.SHORT_ANSWER,
-                         self.proto.interact(self.QUESTION_ID, self.QUESTION,
-                                             self.SHORT_ANSWER))
+        self.callsInteract(self.SHORT_ANSWER, self.SHORT_ANSWER)
 
         self.checkNumberOfAttempts(1)
-        attempt = self.proto.analytics[self.TEST][0]
+        attempt = self.proto.analytics[0]
 
-        self.checkDictField(attempt, 'question', self.QUESTION)
-        self.checkDictField(attempt, 'answer', self.SHORT_ANSWER)
-        self.checkDictField(attempt, 'correct', True)
+        self.validateRecord(attempt, answer=self.SHORT_ANSWER, correct=True)
 
     def testSingleLine_multipleFailsBeforeSuccess(self):
         self.input_choices = self.INCORRECT_ANSWERS + self.SHORT_ANSWER
-        self.assertEqual(self.SHORT_ANSWER,
-                         self.proto.interact(self.QUESTION_ID, self.QUESTION,
-                                             self.SHORT_ANSWER))
+        self.callsInteract(self.SHORT_ANSWER, self.SHORT_ANSWER)
 
         self.checkNumberOfAttempts(1 + len(self.INCORRECT_ANSWERS))
-        for attempt_number, attempt in enumerate(self.proto.analytics[self.TEST]):
-            self.checkDictField(attempt, 'question', self.QUESTION)
+        for attempt_number, attempt in enumerate(self.proto.analytics):
             if attempt_number < len(self.INCORRECT_ANSWERS):
-                self.checkDictField(attempt, 'answer', [self.INCORRECT_ANSWERS[attempt_number]])
-                self.checkDictField(attempt, 'correct', False)
+                self.validateRecord(attempt,
+                                    answer=[self.INCORRECT_ANSWERS[attempt_number]],
+                                    correct=False)
             else:
-                self.checkDictField(attempt, 'answer', self.SHORT_ANSWER)
-                self.checkDictField(attempt, 'correct', True)
+                self.validateRecord(attempt,
+                                    answer=self.SHORT_ANSWER,
+                                    correct=True)
 
     def testMultipleLine_immediatelyCorrect(self):
         self.input_choices = list(self.LONG_ANSWER)
-        self.assertEqual(self.LONG_ANSWER,
-                         self.proto.interact(self.QUESTION_ID, self.QUESTION,
-                                             self.LONG_ANSWER))
+        self.callsInteract(self.LONG_ANSWER, self.LONG_ANSWER)
 
         self.checkNumberOfAttempts(1)
-        attempt = self.proto.analytics[self.TEST][0]
+        attempt = self.proto.analytics[0]
 
-        self.checkDictField(attempt, 'question', self.QUESTION)
-        self.checkDictField(attempt, 'answer', self.LONG_ANSWER)
-        self.checkDictField(attempt, 'correct', True)
+        self.validateRecord(attempt, answer=self.LONG_ANSWER, correct=True)
 
     def testMultipleLine_multipleFailsBeforeSuccess(self):
         self.input_choices = self.LONG_ANSWER[:1] + self.INCORRECT_ANSWERS + \
                              self.LONG_ANSWER
-        self.assertEqual(self.LONG_ANSWER,
-                         self.proto.interact(self.QUESTION_ID, self.QUESTION,
-                                             self.LONG_ANSWER))
+        self.callsInteract(self.LONG_ANSWER, self.LONG_ANSWER)
 
-        print(self.proto.analytics[self.TEST])
         self.checkNumberOfAttempts(1 + len(self.INCORRECT_ANSWERS))
-        for attempt_number, attempt in enumerate(self.proto.analytics[self.TEST]):
-            self.checkDictField(attempt, 'question', self.QUESTION)
-
+        for attempt_number, attempt in enumerate(self.proto.analytics):
             if attempt_number == 0:
-                self.checkDictField(attempt, 'answer', [self.LONG_ANSWER[0], self.INCORRECT_ANSWERS[0]])
-                self.checkDictField(attempt, 'correct', False)
+                self.validateRecord(attempt,
+                    answer=[self.LONG_ANSWER[0], self.INCORRECT_ANSWERS[0]],
+                    correct=False)
             elif attempt_number < len(self.INCORRECT_ANSWERS):
-                self.checkDictField(attempt, 'answer', [self.INCORRECT_ANSWERS[attempt_number]])
-                self.checkDictField(attempt, 'correct', False)
+                self.validateRecord(attempt,
+                    answer=[self.INCORRECT_ANSWERS[attempt_number]],
+                    correct=False)
             else:
-                self.checkDictField(attempt, 'answer', self.LONG_ANSWER)
-                self.checkDictField(attempt, 'correct', True)
+                self.validateRecord(attempt, answer=self.LONG_ANSWER, correct=True)
 
     def testMultipleChoice_immediatelyCorrect(self):
         self.input_choices = ['0']
-        self.assertEqual(self.SHORT_ANSWER,
-                         self.proto.interact(self.QUESTION_ID, self.QUESTION,
-                                             self.SHORT_ANSWER, self.CHOICES,
-                                             randomize=False))
+        self.callsInteract(self.SHORT_ANSWER, self.SHORT_ANSWER,
+                           choices=self.CHOICES, randomize=False)
 
         self.checkNumberOfAttempts(1)
-        attempt = self.proto.analytics[self.TEST][0]
+        attempt = self.proto.analytics[0]
 
-        self.checkDictField(attempt, 'question', self.QUESTION)
-        self.checkDictField(attempt, 'answer', self.SHORT_ANSWER)
-        self.checkDictField(attempt, 'correct', True)
+        self.validateRecord(attempt, answer=self.SHORT_ANSWER, correct=True)
 
     def testMultipleChoice_multipleFailsBeforeSuccess(self):
         self.input_choices = ['1', '2', '0']
-        self.assertEqual(self.SHORT_ANSWER,
-                         self.proto.interact(self.QUESTION_ID, self.QUESTION,
-                                             self.SHORT_ANSWER, self.CHOICES,
-                                             randomize=False))
+        self.callsInteract(self.SHORT_ANSWER, self.SHORT_ANSWER,
+                           choices=self.CHOICES, randomize=False)
 
         self.checkNumberOfAttempts(len(self.input_choices))
-        for attempt_number, attempt in enumerate(self.proto.analytics[self.TEST]):
-            self.checkDictField(attempt, 'question', self.QUESTION)
+        for attempt_number, attempt in enumerate(self.proto.analytics):
             choice = self.input_choices[attempt_number]
-
             if attempt_number < len(self.input_choices) - 1:
-                self.checkDictField(attempt, 'answer', [self.CHOICES[int(choice)]])
-                self.checkDictField(attempt, 'correct', False)
+                self.validateRecord(attempt, answer=[self.CHOICES[int(choice)]],
+                        correct=False)
             else:
-                self.checkDictField(attempt, 'answer', self.SHORT_ANSWER)
-                self.checkDictField(attempt, 'correct', True)
+                self.validateRecord(attempt, answer=self.SHORT_ANSWER, correct=True)

--- a/tests/sources/common/interpreter_test.py
+++ b/tests/sources/common/interpreter_test.py
@@ -59,6 +59,7 @@ class CodeCaseTest(unittest.TestCase):
 
 class UnlockTest(unittest.TestCase):
     CASE_ID = 'Test 1 > Suite 1 > Case 1'
+    UNIQUE_ID_PREFIX = 'assignment\ntest'
 
     def setUp(self):
         self.console = mock.Mock(interpreter.Console)
@@ -77,7 +78,7 @@ class UnlockTest(unittest.TestCase):
             self.assertRaises(unlock.UnlockException, case.unlock, self.CASE_ID,
                               self.interact_fn)
             return
-        case.unlock(self.CASE_ID, self.interact_fn)
+        case.unlock(self.UNIQUE_ID_PREFIX, self.CASE_ID, self.interact_fn)
         self.assertFalse(case.locked)
 
         answers = [line for line in case.lines
@@ -191,6 +192,7 @@ class LockTest:
 
 class ToJsonTest:
     CASE_ID = 'Test 1 > Suite 1 > Case 1'
+    UNIQUE_ID_PREFIX = 'Assignment\nTest'
 
     def setUp(self):
         self.console = mock.Mock(interpreter.Console)
@@ -222,7 +224,7 @@ class ToJsonTest:
             > square(-2)
             3
             """)
-        case.unlock(self.CASE_ID, self.interact_fn)
+        case.unlock(self.UNIQUE_ID_PREFIX, self.CASE_ID, self.interact_fn)
         result = case.to_json()
 
         self.assertIn('code', result)

--- a/tests/sources/common/interpreter_test.py
+++ b/tests/sources/common/interpreter_test.py
@@ -58,6 +58,8 @@ class CodeCaseTest(unittest.TestCase):
         self.assertFalse(case.run())
 
 class UnlockTest(unittest.TestCase):
+    CASE_ID = 'Test 1 > Suite 1 > Case 1'
+
     def setUp(self):
         self.console = mock.Mock(interpreter.Console)
         self.console.PS1 = '> '
@@ -72,9 +74,10 @@ class UnlockTest(unittest.TestCase):
     def calls_unlock(self, code, expect, errors=False):
         case = self.makeCase(code)
         if errors:
-            self.assertRaises(unlock.UnlockException, case.unlock, self.interact_fn)
+            self.assertRaises(unlock.UnlockException, case.unlock, self.CASE_ID,
+                              self.interact_fn)
             return
-        case.unlock(self.interact_fn)
+        case.unlock(self.CASE_ID, self.interact_fn)
         self.assertFalse(case.locked)
 
         answers = [line for line in case.lines
@@ -187,6 +190,8 @@ class LockTest:
 
 
 class ToJsonTest:
+    CASE_ID = 'Test 1 > Suite 1 > Case 1'
+
     def setUp(self):
         self.console = mock.Mock(interpreter.Console)
         self.interact_fn = mock.Mock(side_effect=lambda x, y: x)
@@ -217,7 +222,7 @@ class ToJsonTest:
             > square(-2)
             3
             """)
-        case.unlock(self.interact_fn)
+        case.unlock(self.CASE_ID, self.interact_fn)
         result = case.to_json()
 
         self.assertIn('code', result)

--- a/tests/sources/doctest/load_test.py
+++ b/tests/sources/doctest/load_test.py
@@ -23,10 +23,10 @@ class LoadTest(unittest.TestCase):
 
         self.mockFunction = mock.Mock()
 
-        self.cmd_args = mock.Mock()
+        self.assign = mock.Mock()
 
     def call_load(self, file=VALID_FILE, name=''):
-        return doctest.load(file, name, self.cmd_args)
+        return doctest.load(file, name, self.assign)
 
     def testFileDoesNotExist(self):
         self.mockIsFile.return_value = False

--- a/tests/sources/ok_test/models_test.py
+++ b/tests/sources/ok_test/models_test.py
@@ -5,6 +5,7 @@ import mock
 import unittest
 
 class OkTest(unittest.TestCase):
+    ASSIGNMENT = 'assignment'
     NAME = 'ok test'
     POINTS = 10
     FILE = 'file'
@@ -31,8 +32,8 @@ class OkTest(unittest.TestCase):
         self.hash_fn = mock.Mock()
 
     def makeTest(self, name=NAME, points=POINTS, file=FILE, **fields):
-        return models.OkTest(file, self.suite_map, False, False, name=name,
-                             points=points, **fields)
+        return models.OkTest(file, self.suite_map, self.ASSIGNMENT, False, False,
+                             name=name, points=points, **fields)
 
     def callsRun(self, passed, failed, locked):
         test = self.makeTest(suites=[


### PR DESCRIPTION
@papajohn @ksteph 

This implements the recording of UnlockProtocol attempts. The structure of `messages['unlock']` (data collected by the UnlockProtocol` is the following:

```
{
    string (test name):  [
        {
            "question timestamp": string (format "YYYY-MM-DD HH:mm:ss.microseconds"),
            "answer_timestamp": string (format "YYYY-MM-DD HH:mm:ss.microseconds"),
            "question": string,
            "answer": list of strings (answers may contain multiple lines),
            "correct": boolean
        },
        ...
    ]
}
```

Each test is mapped to a list of unlocking attempts. Note that each Test contains multiple test Cases -- these are the "attempts" that are being recorded. We decided at our meeting that recording the question prompt is okay, but it might be ambiguous what a "prompt" is for Cases that prompt the user multiple times:

```
>>> 4 + 5
?
>>> 2 + 3
?
```

Currently, UnlockProtocol will record ">>> 4 + 5" with the first prompt and ">>> 2 + 3" with the second prompt, even though these two prompts belong to the same test case. Is this okay @ksteph? It might be clearer (for analytical purposes) to record both the "question prompt" as well as a "question id".

@soumyabasu, do you have suggestions on how to record an anonymized student ID?