### PR TITLE
Stop on first failed test case; don't grade right after unlocking

### DIFF
--- a/client/protocols/grading.py
+++ b/client/protocols/grading.py
@@ -28,7 +28,7 @@ class GradingProtocol(models.Protocol):
         significant for analytics. However, all tests must include the number
         passed, the number of locked tests and the number of failed tests.
         """
-        if self.args.score or self.args.export:
+        if self.args.score or self.args.export or self.args.unlock:
             return
 
         format.print_line('~')
@@ -49,7 +49,12 @@ class GradingProtocol(models.Protocol):
             locked += results['locked']
             analytics[test.name] = results
 
-        format.print_progress_bar('Test summary', passed, failed, locked)
+            if not self.args.verbose and (failed > 0 or locked > 0):
+                # Stop at the first failed test
+                break
+
+        format.print_progress_bar('Test summary', passed, failed, locked,
+                                  verbose=self.args.verbose)
         print()
 
         messages['grading'] = analytics

--- a/client/sources/ok_test/doctest.py
+++ b/client/sources/ok_test/doctest.py
@@ -70,4 +70,8 @@ class DoctestSuite(models.Suite):
                 results['passed'] += 1
             else:
                 results['failed'] += 1
+
+            if not success and not self.verbose:
+                # Stop at the first failed test
+                break
         return results

--- a/client/sources/ok_test/models.py
+++ b/client/sources/ok_test/models.py
@@ -51,6 +51,10 @@ class OkTest(models.Test):
             failed += results['failed']
             locked += results['locked']
 
+            if not self.verbose and (failed > 0 or locked > 0):
+                # Stop at the first failed test
+                break
+
         if locked > 0:
             print()
             print('There are still locked tests! '

--- a/client/utils/format.py
+++ b/client/utils/format.py
@@ -48,13 +48,21 @@ def print_line(style, length=69):
     """
     print(style * length)
 
-def print_progress_bar(header, passed, failed, locked):
+def print_progress_bar(header, passed, failed, locked, verbose=True):
     print_line('-')
     print(header)
-    print('    Passed: {}'.format(passed))
-    print('    Failed: {}'.format(failed))
     if locked > 0:
         print('    Locked: {}'.format(locked))
+    if verbose:
+        print('    Passed: {}'.format(passed))
+        print('    Failed: {}'.format(failed))
+    elif failed > 0:
+        print('    {} test cases passed before encountering '
+              'first failed test case'.format(passed))
+        return
+    else:
+        print('    {} test cases passed!'.format(passed))
+        return
 
     # Print [oook.....] progress bar
     total = passed + failed + locked

--- a/tests/protocols/grading_test.py
+++ b/tests/protocols/grading_test.py
@@ -10,6 +10,7 @@ class GradingProtocolTest(unittest.TestCase):
         self.cmd_args = mock.Mock()
         self.cmd_args.score = False
         self.cmd_args.export = False
+        self.cmd_args.unlock = False
         self.assignment = mock.Mock()
         self.proto = grading.protocol(self.cmd_args, self.assignment)
 

--- a/tests/sources/ok_test/models_test.py
+++ b/tests/sources/ok_test/models_test.py
@@ -31,7 +31,7 @@ class OkTest(unittest.TestCase):
         self.hash_fn = mock.Mock()
 
     def makeTest(self, name=NAME, points=POINTS, file=FILE, **fields):
-        return models.OkTest(file, self.suite_map, False, False, name=name,
+        return models.OkTest(file, self.suite_map, True, False, name=name,
                              points=points, **fields)
 
     def callsRun(self, passed, failed, locked):


### PR DESCRIPTION
Resolves #96 and #98. The command line options remain the same:

```
python3 ok -q question_name -u
python3 ok -q question_name
```

However, if the `-u` flag is specified, `GradingProtocol` does not get run. In addition, GradingProtocol stops at the very "first" failed test case.