### PR TITLE
Allow staff to specify default tests

### DIFF
--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -50,7 +50,7 @@ def parse_input():
                         help="Scores the assignment")
     parser.add_argument('--config', type=str,
                         help="Specify a configuration file")
-    parser.add_argument('--timeout', type=int, default=5,
+    parser.add_argument('--timeout', type=int, default=10,
                         help="set the timeout duration for running tests")
 
     # Submission Export

--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -36,6 +36,8 @@ def parse_input():
                         help="toggle interactive mode")
     parser.add_argument('-v', '--verbose', action='store_true',
                         help="print more output")
+    parser.add_argument('--all', action='store_true',
+                        help="run tests for all questions in config file")
     parser.add_argument('--submit', action='store_true',
                         help="Submit assignment")
     parser.add_argument('--backup', action='store_true',
@@ -48,7 +50,7 @@ def parse_input():
                         help="Scores the assignment")
     parser.add_argument('--config', type=str,
                         help="Specify a configuration file")
-    parser.add_argument('--timeout', type=int, default=10,
+    parser.add_argument('--timeout', type=int, default=5,
                         help="set the timeout duration for running tests")
 
     # Submission Export

--- a/client/config.ok
+++ b/client/config.ok
@@ -9,6 +9,9 @@
         "hw1.py:square": "doctest",
         "hw1.py:double": "doctest"
     },
+    "default_tests": [
+        "square"
+    ],
     "protocols": [
         "restore",
         "export",

--- a/demo/doctest/config.ok
+++ b/demo/doctest/config.ok
@@ -8,6 +8,9 @@
         "hw1.py:square": "doctest",
         "hw1.py:double": "doctest"
     },
+    "default_tests": [
+        "square"
+    ],
     "protocols": [
         "file_contents",
         "grading",

--- a/demo/ok_test/config.ok
+++ b/demo/ok_test/config.ok
@@ -7,6 +7,9 @@
     "tests": {
         "tests/[!_]*.py": "ok_test"
     },
+    "default_tests": [
+        "q2"
+    ],
     "protocols": [
         "file_contents",
         "unlock",


### PR DESCRIPTION
Resolves #100 .

Staff members can specify an optional "default_tests" field in `*.ok`:

```
"tests": {
    ...
},
"default_tests": [
    "square",    // The string that students would input on the command line to specify this test
    ...
]
```

When `ok` is run without any `-q` flags, only tests in the `default_tests` list are run. I added an `--all` flag that allows students to run **every** test, not just the default tests.