### PR TITLE
Change urlopen timeout to seconds instead of milliseconds

### DIFF
--- a/client/protocols/backup.py
+++ b/client/protocols/backup.py
@@ -146,11 +146,11 @@ class BackupProtocol(models.Protocol):
 
         if not error_msg and message_list:
             # No errors occurred, but could not complete request within TIMEOUT.
-            print('{action}... {percent}% complete'.format(action=action,
-                percent=100 - round(len(message_list) * 100 / num_messages, 2)))
+            print()     # Preserve progress bar.
             print('Could not {} within {} seconds.'.format(action.lower(), self.TIMEOUT))
 
         elif message_list:
+            # If not all messages could be backed up successfully.
             print()     # Preserve progress bar.
             print('Could not', action.lower() + ':', error_msg)
         else:

--- a/client/protocols/backup.py
+++ b/client/protocols/backup.py
@@ -90,12 +90,12 @@ class BackupProtocol(models.Protocol):
 
 
     def send_all_messages(self, access_token, message_list):
-        action = 'Submitting' if self.args.submit else 'Backing up'
+        action = 'Submit' if self.args.submit else 'Back up'
         num_messages = len(message_list)
 
         send_all = self.args.submit or self.args.backup
         retries = self.RETRY_LIMIT
-        stop_time = datetime.datetime.now() + datetime.timedelta(milliseconds=1000 * self.TIMEOUT)
+        stop_time = datetime.datetime.now() + datetime.timedelta(seconds=self.TIMEOUT)
 
         first_response = None
         error_msg = ''
@@ -118,9 +118,14 @@ class BackupProtocol(models.Protocol):
             except socket.timeout as ex:
                 log.warning("socket.timeout: %s", str(ex))
                 retries -= 1
-                error_msg = 'Connection timed out. ' + \
-                            'Please check your network connection.'
+                error_msg = 'Connection timed out after {} seconds. ' + \
+                            'Please check your network connection.'.format(self.TIMEOUT)
             except (urllib.error.URLError, urllib.error.HTTPError) as ex:
+                log.warning('%s: %s', ex.__class__.__name__, str(ex))
+                if not hasattr(ex, 'read'):
+                    error_msg = 'Please check your network connection'
+                    continue
+
                 response_json = json.loads(ex.read().decode('utf-8'))
 
                 log.warning('%s: %s', ex.__class__.__name__, str(ex))
@@ -139,13 +144,15 @@ class BackupProtocol(models.Protocol):
 
                 message_list.pop()
 
-        if retries <= 0:
+        if not error_msg and message_list:
+            # No errors occurred, but could not complete request within TIMEOUT.
+            print('{action}... {percent}% complete'.format(action=action,
+                percent=100 - round(len(message_list) * 100 / num_messages, 2)))
+            print('Could not {} within {} seconds.'.format(action.lower(), self.TIMEOUT))
+
+        elif message_list:
             print()     # Preserve progress bar.
-            print('Error while', action.lower() + ':', error_msg)
-        elif not send_all and datetime.datetime.now() > stop_time:
-            print()     # Preserve progress bar.
-            print('Could not back up: '
-                  'Connection to server timed out after {} milliseconds'.format(self.TIMEOUT))
+            print('Could not', action.lower() + ':', error_msg)
         else:
             print('{action}... 100% complete'.format(action=action))
             return first_response

--- a/client/protocols/backup.py
+++ b/client/protocols/backup.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 
 class BackupProtocol(models.Protocol):
 
-    TIMEOUT = 500
+    TIMEOUT = 0.5
     RETRY_LIMIT = 5
     BACKUP_FILE = ".ok_messages"
     SUBMISSION_ENDPOINT = '{prefix}://{server}/api/v1/submission?'
@@ -84,6 +84,9 @@ class BackupProtocol(models.Protocol):
                     'SSL Bindings are not installed. '
                     'You can install python3 SSL bindings or run OK locally:\n'
                     '\tpython3 ok --local')
+        else:
+            log.info('SSL bindings are available.')
+
 
 
     def send_all_messages(self, access_token, message_list):
@@ -92,7 +95,7 @@ class BackupProtocol(models.Protocol):
 
         send_all = self.args.submit or self.args.backup
         retries = self.RETRY_LIMIT
-        stop_time = datetime.datetime.now() + datetime.timedelta(milliseconds=self.TIMEOUT)
+        stop_time = datetime.datetime.now() + datetime.timedelta(milliseconds=1000 * self.TIMEOUT)
 
         first_response = None
         error_msg = ''

--- a/client/utils/network.py
+++ b/client/utils/network.py
@@ -6,8 +6,8 @@ import logging
 
 log = logging.getLogger(__name__)
 
-TIMEOUT = 500
-            
+TIMEOUT = 1
+
 def api_request(access_token, server, route, insecure=False, arguments={}):
     """Makes a request to the server API and returns the result."""
     try:

--- a/client/utils/software_update.py
+++ b/client/utils/software_update.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 # TODO(sumukh): does software update require ssl?
 VERSION_ENDPOINT = 'https://{server}/api/v1/version'
-TIMEOUT = 500  # milliseconds
+TIMEOUT = 0.5  # seconds
 
 def check_version(server, version, filename):
     """Check for the latest version of OK and update accordingly."""

--- a/demo/ok_test/config.ok
+++ b/demo/ok_test/config.ok
@@ -12,6 +12,7 @@
         "unlock",
         "grading",
         "scoring",
-        "analytics"
+        "analytics",
+        "backup"
     ]
 }


### PR DESCRIPTION
It turns out `urllib.request.urlopen`'s timeout is specified in seconds, not milliseconds. ok-client has been assuming it's in milliseconds for a long time now. Oops.