### PR TITLE
Adds option to ExportProtocol to download latest instead of final submissions

### DIFF
--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -56,6 +56,8 @@ def parse_input():
     # Submission Export
     parser.add_argument('--export', action='store_true',
                         help="Downloads all submissions for the current assignment")
+    parser.add_argument('--latest', action='store_true',
+                        help="When used with --export, downloads latest submissions instead of final submissions")
 
     # Debug information
     parser.add_argument('--version', action='store_true',

--- a/client/protocols/export.py
+++ b/client/protocols/export.py
@@ -93,7 +93,7 @@ class ExportProtocol(models.Protocol):
             os.fsync(f.fileno())
             
     def get_final_submission(self, student, assign_id):
-        """Gets the final_submisssion from the server for use in download_submission"""
+        """Gets the final_submission from the server for use in download_submission"""
         params = {'assignment': assign_id}
         response = self.request('user/{0}/final_submission'.format(student[0]),
             params)


### PR DESCRIPTION
As discussed in [ok#493](https://github.com/Cal-CS-61A-Staff/ok/issues/493), this adds an additional option to `ExportProtocol` to download the latest submission for each student rather than their final submission. The default behavior for `--export` is unchanged, but adding the `--latest` flag will download latest instead of final submissions.