### PR TITLE
Extensions + Notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,22 +67,20 @@ from . import Extension, extension
 @extension
 class SampleExt(Extension):
 	
-	def setup(self, assign):
+	def setup(self, assign=None):
 		""" sets up the sample extension """
 		print('Setting up sample extension')
 		# all args loaded into the self.args dictionary
-		if self.args.flag == 'arg':
-		    # full control over the assignment object
-            assign.dump_tests = lambda: 'Tests hidden.'
-
-	def run(self, assign):
-	    """ run after each test is run """
-	    print('Running sample extension')
+		if assign and self.args.flag == 'arg':
+			# full control over the assignment object
+			assign.dump_tests = lambda: 'Tests hidden.'
 	    
 	def teardown(self, assign):
 	    """ run before the test results are dumped """
 	    print('Tearing down sample extension')
-		
+
+# required
+Extension = SampleExt
 ```
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -62,26 +62,19 @@ from . import Extension, extension
 # all extensions must feature BOTH this decorator AND subclass Extension
 @extension
 class SampleExt(Extension):
-
-    def parse_args(parser):
-        """ Optionally add arguments - this method may be omitted """
-        parser.add_argument('--prepare', action='store_true',
-                            help='Prepare the plugin for action')
-        return parser.parse_args()
 	
 	def setup(self, assign):
 		""" sets up the sample extension """
 		print('Setting up sample extension')
 		# full control over the assignment object
-		if self.args.prepare:
-		    assign.dump_tests = lambda: 'Tests hidden.'
-		
+        assign.dump_tests = lambda: 'Tests hidden.'
+
 	def run(self, assign):
 	    """ run after each test is run """
 	    print('Running sample extension')
 	    
 	def teardown(self, assign):
-	    """ run after the test results are dumped """
+	    """ run before the test results are dumped """
 	    print('Tearing down sample extension')
 		
 ```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,51 @@ directory. Every component of the client should have plenty of tests.
 To run all tests, use the following command:
 
     nosetests tests
+    
+## Extensions
+
+Extensions are invoked using a special ok flag.
+
+```
+python3 ok --extension [extension]
+```
+
+Each extension may have its own set of arguments. Append `--help` to the
+above command to find out more.
+
+To create a new extension, create a new python module under the
+`client/extensions` directory. The extension must consist of the following,
+at the bare minimum:
+
+```
+from . import Extension, extension
+
+# all extensions must feature BOTH this decorator AND subclass Extension
+@extension
+class SampleExt(Extension):
+
+    def parse_args(parser):
+        """ Optionally add arguments - this method may be omitted """
+        parser.add_argument('--prepare', action='store_true',
+                            help='Prepare the plugin for action')
+        return parser.parse_args()
+	
+	def setup(self, assign):
+		""" sets up the sample extension """
+		print('Setting up sample extension')
+		# full control over the assignment object
+		if self.args.prepare:
+		    assign.dump_tests = lambda: 'Tests hidden.'
+		
+	def run(self, assign):
+	    """ run after each test is run """
+	    print('Running sample extension')
+	    
+	def teardown(self, assign):
+	    """ run after the test results are dumped """
+	    print('Tearing down sample extension')
+		
+```
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,12 @@ Extensions are invoked using a special ok flag.
 python3 ok --extension [extension]
 ```
 
-Each extension may have its own set of arguments. Append `--help` to the
-above command to find out more.
+Each extension may have its own set of flags and arguments. Use the
+`--extargs` flag to pass these to the extension.
+
+```
+python3 ok --extension [extension] --extargs {flag:arg}
+```
 
 To create a new extension, create a new python module under the
 `client/extensions` directory. The extension must consist of the following,
@@ -66,8 +70,10 @@ class SampleExt(Extension):
 	def setup(self, assign):
 		""" sets up the sample extension """
 		print('Setting up sample extension')
-		# full control over the assignment object
-        assign.dump_tests = lambda: 'Tests hidden.'
+		# all args loaded into the self.args dictionary
+		if self.args.flag == 'arg':
+		    # full control over the assignment object
+            assign.dump_tests = lambda: 'Tests hidden.'
 
 	def run(self, assign):
 	    """ run after each test is run """

--- a/client/cli/common/assignment.py
+++ b/client/cli/common/assignment.py
@@ -166,11 +166,12 @@ class Assignment(core.Serializable):
             log.info('Loaded protocol "{}"'.format(proto))
 
     def _print_header(self):
-        format.print_line('=')
-        print('Assignment: {}'.format(self.name))
-        print('OK, version {}'.format(client.__version__))
-        format.print_line('=')
-        print()
+        if not self.cmd_args.extargs:
+            format.print_line('=')
+            print('Assignment: {}'.format(self.name))
+            print('OK, version {}'.format(client.__version__))
+            format.print_line('=')
+            print()
 
 def _has_subsequence(string, pattern):
     """Returns true if the pattern is a subsequence of string."""

--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -90,12 +90,12 @@ def parse_input():
     parser.add_argument('--extargs', type=yaml.load,
                         help="dictionary of commands and args")
 
-    return parser, parser.parse_args()
+    return parser.parse_args()
 
 
 def main():
     """Run all relevant aspects of ok.py."""
-    parser, args = parse_input()
+    args = parse_input()
 
     log.setLevel(logging.DEBUG if args.debug else logging.ERROR)
     log.debug(args)

--- a/client/cli/publish.py
+++ b/client/cli/publish.py
@@ -17,6 +17,7 @@ REQUIRED_FILES = [
 ]
 REQUIRED_FOLDERS = [
     'utils',
+    'extensions',
 ]
 COMMAND_LINE = [
     'ok',

--- a/client/extensions/__init__.py
+++ b/client/extensions/__init__.py
@@ -1,0 +1,44 @@
+"""
+
+Extensions Manager
+
+"""
+
+import importlib
+
+
+def load(ext):
+	""" Loads the extension """
+	module = importlib.import_module(ext)
+	return module.Extension()
+
+
+def extension(cls):
+	""" wrapper for all Extensions """
+	def Extension(*args, **kwargs):
+		return cls(*args, **kwargs)
+	return Extension
+
+
+class Extension:
+	""" Base class for all extensions """
+	
+	_args = None
+	terminate_after_load = False
+	terminate_after_run = False
+	
+	def parse_args(self, parser):
+		""" optionally add custom args and parse the results """
+		return parser.parse_args()
+	
+	def setup(self, assign):
+		""" setup extension """
+		raise NotImplementedError()
+		
+	def run(self, assign):
+		""" tell the Extension to do its thing """
+		raise NotImplementedError()
+	
+	def teardown(self, assign):
+		""" teardown extension """
+		raise NotImplementedError()

--- a/client/extensions/__init__.py
+++ b/client/extensions/__init__.py
@@ -5,12 +5,13 @@ Extensions Manager
 """
 
 import importlib
+import os
 
 
-def load(ext):
+def load(ext, extargs):
 	""" Loads the extension """
-	module = importlib.import_module(ext)
-	return module.Extension()
+	module = importlib.import_module('client.extensions.%s' % ext)
+	return module.Extension(extargs)
 
 
 def extension(cls):
@@ -20,16 +21,29 @@ def extension(cls):
 	return Extension
 
 
+class Namespace:
+	
+	vars = {}
+	
+	def __setattr__(self, key, value):
+		self.vars[key] = value
+		
+	def __getattr__(self, key):
+		if key not in self.vars:
+			return None
+		return self.vars[key]
+
+
 class Extension:
 	""" Base class for all extensions """
 	
 	_args = None
-	terminate_after_load = False
+	terminate_after_setup = False
 	terminate_after_run = False
 	
-	def parse_args(self, parser):
-		""" optionally add custom args and parse the results """
-		return parser.parse_args()
+	def __init__(self, args):
+		self.args = Namespace()
+		[setattr(self.args, k, v) for k, v in (args or {}).items()]
 	
 	def setup(self, assign):
 		""" setup extension """

--- a/client/extensions/__init__.py
+++ b/client/extensions/__init__.py
@@ -5,7 +5,6 @@ Extensions Manager
 """
 
 import importlib
-import os
 
 
 def load(ext, extargs):
@@ -22,6 +21,7 @@ def extension(cls):
 
 
 class Namespace:
+	""" container for all args passed via --extargs"""
 	
 	vars = {}
 	
@@ -42,17 +42,25 @@ class Extension:
 	terminate_after_run = False
 	
 	def __init__(self, args):
+		""" Setup and save namespace """
 		self.args = Namespace()
 		[setattr(self.args, k, v) for k, v in (args or {}).items()]
 	
-	def setup(self, assign):
+	def setup(self, *args):
 		""" setup extension """
 		raise NotImplementedError()
-		
-	def run(self, assign):
-		""" tell the Extension to do its thing """
-		raise NotImplementedError()
 	
-	def teardown(self, assign):
+	def teardown(self, *args):
 		""" teardown extension """
 		raise NotImplementedError()
+
+	@staticmethod
+	def bind(obj, method_old_name, method_new):
+		""" Bind an extension function to an existing function """
+		print('[Notebook] Binding function "%s" to "%s"' % (method_new.__name__, method_old_name))
+		method_old = getattr(obj, method_old_name)
+		
+		def replacement(*args, **kwargs):
+			return method_new(method_old, *args, **kwargs)
+		replacement.__name__ = method_old_name
+		setattr(obj, method_old_name, replacement)

--- a/client/extensions/notebook.py
+++ b/client/extensions/notebook.py
@@ -9,8 +9,18 @@ Extension for Jupyter Notebook
 """
 
 from . import Extension, extension
+import json
 import os
 import subprocess
+
+
+def shell(f):
+	""" Wraps all shell commands, prints command first """
+	def helper(*args, **kwargs):
+		print('[Notebook] %s' % str(args[1:]))
+		return f(*args, **kwargs)
+	helper.__name__ = f.__name__
+	return helper
 
 
 @extension
@@ -26,9 +36,10 @@ class NotebookExt(Extension):
 		""" setup dependencies, and cache code blocks """
 		if self.args.nb:
 			self.terminate_after_setup = True
+			self.extract_book(self.args.nb)
 		else:
 			self.setup_makefile()
-			self.call('make', 'all')
+			self.call('make', 'all', '--quiet')
 		return self
 	
 	def run(self, assign):
@@ -42,16 +53,22 @@ class NotebookExt(Extension):
 	# HELPER METHODS #
 	##################
 	
+	@shell
 	def call(self, *cmd):
 		""" Shell command """
-		print('[Notebook] %s' % str(cmd))
-		print(subprocess.call(cmd))
+		return subprocess.call(cmd)
+		
+	@shell
+	def return_output(self, *cmd):
+		""" Get output of shell command """
+		return subprocess.check_output(cmd)
 
 	def setup_makefile(self):
 		""" Setup makefile, mapping python files to notebooks """
 		print('[Notebook] Generating makefile dependencies.')
 		template = """\
 {name}.py: {name}.ipynb
+	@echo "[Notebook] Extracting {name}.py from {name}.ipynb"
 	ok --extension notebook --extargs '{args}'
 		"""
 		books = [f.split('.')[0] for f in os.listdir('.') if f.endswith('.ipynb')]
@@ -60,5 +77,19 @@ class NotebookExt(Extension):
 		content = 'all: %s\n\n' % ' '.join(all)
 		content += '\n'.join(deps)
 		open('makefile', 'w').write(content)
+		
+	def extract_book(self, name):
+		""" Extract python script from IPython source """
+		book = '%s.ipynb' % name
+		py = '%s.py' % name
+		cells = json.loads(open(book, 'r').read())['cells']
+		scripts = [self.extract_lines(cell['source']) 
+		           for cell in cells if cell['cell_type'] == 'code']
+		script = '\n'.join(scripts)
+		open(py, 'w').write(script)
+		
+	def extract_lines(self, lines):
+		""" Extracts code segment from IPython source block """
+		return '\n'.join([line for line in lines if line[0] != '%'])
 
 Extension = NotebookExt

--- a/client/extensions/notebook.py
+++ b/client/extensions/notebook.py
@@ -14,6 +14,13 @@ import os
 import subprocess
 
 
+MAKEFILE_TEMPLATE = """\
+{name}.py: {name}.ipynb
+	@echo "[Notebook] Extracting {name}.py from {name}.ipynb"
+	ok --extension notebook --extargs '{args}'
+"""
+
+
 def shell(f):
 	""" Wraps all shell commands, prints command first """
 	def helper(*args, **kwargs):
@@ -66,16 +73,12 @@ class NotebookExt(Extension):
 	def setup_makefile(self):
 		""" Setup makefile, mapping python files to notebooks """
 		print('[Notebook] Generating makefile dependencies.')
-		template = """\
-{name}.py: {name}.ipynb
-	@echo "[Notebook] Extracting {name}.py from {name}.ipynb"
-	ok --extension notebook --extargs '{args}'
-		"""
-		books = [f.split('.')[0] for f in os.listdir('.') if f.endswith('.ipynb')]
-		deps = [template.format(name=f, args=str({"nb": f})) for f in books]
-		all = ['%s.py' % f for f in books]
-		content = 'all: %s\n\n' % ' '.join(all)
-		content += '\n'.join(deps)
+		books = [f.split('.')[0] for f in os.listdir('.') 
+		         if f.endswith('.ipynb')]
+		deps = '\n'.join([MAKEFILE_TEMPLATE.format(
+			name=f, args=str({"nb": f})) for f in books])
+		all = ' '.join(['%s.py' % f for f in books])
+		content = 'all: %s\n\n%s' % (all, deps)
 		open('makefile', 'w').write(content)
 		
 	def extract_book(self, name):

--- a/client/extensions/notebook.py
+++ b/client/extensions/notebook.py
@@ -9,32 +9,56 @@ Extension for Jupyter Notebook
 """
 
 from . import Extension, extension
+import os
+import subprocess
 
 
 @extension
 class NotebookExt(Extension):
-	
-	terminate_after_load = True
+
 	cache_dir = 'cache'
 	
 	######################
 	# OBLIGATORY METHODS #
 	######################
-	
-	def parse_args(self, parser):
-		""" add custom notebook args """
-	
+
 	def setup(self, assign):
 		""" setup dependencies, and cache code blocks """
+		if self.args.nb:
+			self.terminate_after_setup = True
+		else:
+			self.setup_makefile()
+			self.call('make', 'all')
+		return self
 	
 	def run(self, assign):
 		""" feed test data back to IPython """
+		return self
 		
 	def teardown(self, assign):
-		pass
+		return self
 	
 	##################
 	# HELPER METHODS #
 	##################
 	
-	
+	def call(self, *cmd):
+		""" Shell command """
+		print('[Notebook] %s' % str(cmd))
+		print(subprocess.call(cmd))
+
+	def setup_makefile(self):
+		""" Setup makefile, mapping python files to notebooks """
+		print('[Notebook] Generating makefile dependencies.')
+		template = """\
+{name}.py: {name}.ipynb
+	ok --extension notebook --extargs '{args}'
+		"""
+		books = [f.split('.')[0] for f in os.listdir('.') if f.endswith('.ipynb')]
+		deps = [template.format(name=f, args=str({"nb": f})) for f in books]
+		all = ['%s.py' % f for f in books]
+		content = 'all: %s\n\n' % ' '.join(all)
+		content += '\n'.join(deps)
+		open('makefile', 'w').write(content)
+
+Extension = NotebookExt

--- a/client/extensions/notebook.py
+++ b/client/extensions/notebook.py
@@ -1,0 +1,40 @@
+"""
+
+Extension for Jupyter Notebook
+
+- prepares makefile dependencies
+- convert .ipynb notebooks into .py files
+- cache and update python files accordingly
+
+"""
+
+from . import Extension, extension
+
+
+@extension
+class NotebookExt(Extension):
+	
+	terminate_after_load = True
+	cache_dir = 'cache'
+	
+	######################
+	# OBLIGATORY METHODS #
+	######################
+	
+	def parse_args(self, parser):
+		""" add custom notebook args """
+	
+	def setup(self, assign):
+		""" setup dependencies, and cache code blocks """
+	
+	def run(self, assign):
+		""" feed test data back to IPython """
+		
+	def teardown(self, assign):
+		pass
+	
+	##################
+	# HELPER METHODS #
+	##################
+	
+	

--- a/client/extensions/notebook.py
+++ b/client/extensions/notebook.py
@@ -120,8 +120,8 @@ class NotebookExt(Extension):
 		book = '%s.ipynb' % name
 		py = '%s.py' % name
 		print('[Notebook] Extracting {book} from {py} ...'.format(**locals()))
-		cells = json.loads(open(book, 'r').read())['cells']
-		self.files[book] = cells
+		data = json.loads(open(book, 'r').read())
+		self.files[book], cells = data, data['cells']
 		scripts = [self.extract_lines(cell['source']) 
 		           for cell in cells if cell['cell_type'] == 'code']
 		script = '\n\n'.join(scripts)

--- a/client/extensions/notebook.py
+++ b/client/extensions/notebook.py
@@ -137,7 +137,9 @@ this output: %s' % messages)
 	
 	def exclude_lines(self, lines):
 		""" Filters out specific lines """
-		return [line for line in lines if line[0] != '%']
+		if lines[0].startswith('## ok'):
+			return [line for line in lines if line[0] != '%']
+		return []
 	
 	def inject(self, test, grade, output):
 		""" Inject the test results back into the file. """
@@ -184,7 +186,8 @@ https://github.com/Cal-CS-61A-Staff/ok-client.' % method)
 			match = template.findall(line)
 			if len(match) > 0:
 				methods.append(match[0][1])
-		cell['outputs'] = []
+		if 'outputs' in cell:
+			cell['outputs'] = []
 		for method in methods:
 			self.methods[method] = {
 				'cell': cell,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ nose==1.3.3
 pylint==1.2.1
 mock==1.0.1
 coverage==3.7.1
+pyyaml==3.11


### PR DESCRIPTION
- extensions infrastructure
- Jupyter Notebook extension, so that ok tests can be run for notebooks
- UI at https://github.com/alvinwan/notebook/pull/1

**Update**

Extensions:
- `bind` function allows you to bind a custom function to any existing `ok-client` method

Notebook extension:
- tests any number of notebooks, with each representing a python file
- methods that require testing can be squished into a cell (ext. will automatically append all test output for each test, to that cell) i.e., not restricted to one-test-case-per-cell
- tests may be randomly placed in any notebook (ext. will look for test cases in all files)
- tests only against cells prepended by `## ok`
- `python3 ok --extension notebook`
- generates a `makefile` so that only updated notebooks are re-converted into python files
- alternatively -- after running the `notebook` ext. at least once -- use `make all` to re-generate python files

@albert12132 do you have objections/suggestions for how extensions are handled?

**Using the UI**:
![ok-client-notebook](https://cloud.githubusercontent.com/assets/2068077/8790977/5182621e-2f09-11e5-88b5-7ea21b82b362.gif)

** Old (Using CLI) **:
![ok-client-notebook](https://cloud.githubusercontent.com/assets/2068077/8771287/77c08112-2e74-11e5-937a-ac8dcec1aa35.gif)