### PR TITLE
Make traceback scraping more robust to test errors.

### DIFF
--- a/client/sources/common/pyconsole.py
+++ b/client/sources/common/pyconsole.py
@@ -51,8 +51,9 @@ class PythonConsole(interpreter.Console):
             raise interpreter.ConsoleException(e)
         except Exception as e:
             stacktrace = traceback.format_exc()
-            token = '<module>\n'
-            index = stacktrace.rfind(token) + len(token)
+            token = '<string>'
+            token_start = stacktrace.rfind(token)
+            index = stacktrace.find('\n', token_start) + 1
             stacktrace = stacktrace[index:].rstrip('\n')
             if '\n' in stacktrace:
                 print('Traceback (most recent call last):')


### PR DESCRIPTION
The traceback scraper used to look for `<module>`, but that string doesn't always appear. This meant that rfind was returning -1, which was unchecked. This update essentially looks for `<string>.*\n` and only keeps the lines after the match.

Tracebacks can either be of the form

```
  <stuff>
  File "<string>", line 1, in <module>
  <desired traceback>
```

if the error happens in student code, or

```
  <stuff>
  File "<string>", line 1
  <desired traceback>
```

if the error happens in test code.