### PR TITLE
Add support for doctest names with dots.

### DIFF
--- a/client/__init__.py
+++ b/client/__init__.py
@@ -1,4 +1,4 @@
-__version__ = 'v1.4.2'
+__version__ = 'v1.4.3'
 FILE_NAME = 'ok'
 
 import os

--- a/client/sources/doctest/__init__.py
+++ b/client/sources/doctest/__init__.py
@@ -53,10 +53,18 @@ def _load_tests(file, module, assign):
     return tests
 
 def _load_test(file, module, name, assign):
-    if not hasattr(module, name):
-        raise ex.LoadingException('Module {} has no function {}'.format(
-                                  module.__name__, name))
-    func = getattr(module, name)
+    namespace, name_to_find = module, name
+    while name_to_find:
+        if '.' in name_to_find:
+            curr_name, name_to_find = name_to_find.split('.', 1)
+        else:
+            curr_name, name_to_find = name_to_find, ''
+        if not hasattr(namespace, curr_name):
+            raise ex.LoadingException('Module {} has no attribute {}'.format(
+                module.__name__, name))
+        namespace = getattr(namespace, curr_name)
+    func = namespace
+
     if not callable(func):
         raise ex.LoadingException('Attribute {} is not a function'.format(name))
 

--- a/tests/sources/doctest/load_test.py
+++ b/tests/sources/doctest/load_test.py
@@ -8,6 +8,7 @@ class LoadTest(unittest.TestCase):
     VALID_FILE = 'valid.py'
     INVALID_FILE = 'invalid.ext'
     FUNCTION = 'function'
+    METHOD = 'cls.method'
 
     def setUp(self):
         self.patcherIsFile = mock.patch('os.path.isfile')
@@ -21,6 +22,7 @@ class LoadTest(unittest.TestCase):
         self.mockModule = mock.MagicMock()
         self.mockLoadModule.return_value = self.mockModule
 
+        self.cls = mock.Mock()
         self.mockFunction = mock.Mock()
 
         self.assign = mock.Mock()
@@ -81,3 +83,18 @@ class LoadTest(unittest.TestCase):
         self.assertEqual(1, len(result))
         self.assertIn(self.FUNCTION, result)
         self.assertIsInstance(result[self.FUNCTION], models.Doctest)
+
+    def testSpecificMethod(self):
+        self.mockFunction.__doc__ = """
+        >>> 1 + 2
+        3
+        """
+        setattr(self.cls, self.METHOD.split('.')[1], self.mockFunction)
+        setattr(self.mockModule, self.METHOD.split('.')[0], self.cls)
+
+        result = self.call_load(name=self.METHOD)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(1, len(result))
+        self.assertIn(self.METHOD, result)
+        self.assertIsInstance(result[self.METHOD], models.Doctest)


### PR DESCRIPTION
This PR allows us to reference a method's doctests directly, rather than by duplicating the code in a separate ok_test file. Valid test names now include names of the form `foo.py:Foo.bar`.