### PR TITLE
No timeout for --backup and --submit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin
+env
 include
 lib
 man
@@ -18,6 +19,7 @@ tmp
 # pip-related files
 *.egg-info
 dist
+pip-selftest.json
 
 # ok-related files
 *.ok_refresh

--- a/client/protocols/backup.py
+++ b/client/protocols/backup.py
@@ -16,7 +16,6 @@ class BackupProtocol(models.Protocol):
 
     # Timeouts are specified in seconds.
     SHORT_TIMEOUT = 1
-    LONG_TIMEOUT = 15
 
     RETRY_LIMIT = 5
     BACKUP_FILE = ".ok_messages"
@@ -97,10 +96,14 @@ class BackupProtocol(models.Protocol):
         num_messages = len(message_list)
 
         send_all = self.args.submit or self.args.backup
-        timeout = self.LONG_TIMEOUT if send_all else self.SHORT_TIMEOUT
+        if send_all:
+            timeout = None
+            stop_time = datetime.datetime.max
+        else:
+            timeout = self.SHORT_TIMEOUT
+            stop_time = datetime.datetime.now() + datetime.timedelta(seconds=timeout)
+            log.info('Setting timeout to %d seconds', timeout)
         retries = self.RETRY_LIMIT
-        stop_time = datetime.datetime.now() + datetime.timedelta(seconds=timeout)
-        log.info('Setting timeout to %d seconds', timeout)
 
         first_response = None
         error_msg = ''


### PR DESCRIPTION
There's currently no way to force a submit. The default timeout is 15 seconds.

See https://piazza.com/class/id52tzq2i7yfx?cid=2747 for this issue in the wild.