### PR TITLE
Resolve issue with Python errors being silenced in Scheme tests

### DIFF
--- a/client/sources/scheme_test/models.py
+++ b/client/sources/scheme_test/models.py
@@ -98,6 +98,7 @@ class SchemeTest(models.Test):
             timer.timed(self.timeout, self.scheme.read_eval_print_loop,
                         (next_line, self.scheme.create_global_frame()))
         except BaseException as e:
+            output.on()
             if reader:
                 print("Tests terminated due to unhandled exception "
                       "after line {}:\n"


### PR DESCRIPTION
Add missing output.on() so useful Python error messages are printed.