### PR TITLE
Automatically compare test output when using local ./sqlite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ tmp
 # pip-related files
 *.egg-info
 dist
-pip-selftest.json
+pip-selfcheck.json
 
 # ok-related files
 *.ok_refresh

--- a/client/sources/ok_test/sqlite.py
+++ b/client/sources/ok_test/sqlite.py
@@ -45,19 +45,14 @@ class SqliteConsole(interpreter.Console):
         env = dict(os.environ,
                    PATH=os.getcwd() + os.pathsep + os.environ["PATH"])
         if self._has_sqlite_cli(env):
-            print('Unfortunately, OK is unable to use sqlite3 to test your code directly.')
-            print('Here is a transcript of what your code does in the sqlite3 interpreter.')
-            print()
-            test, expected, result = self._use_sqlite_cli(env)
-            print('TEST:')
-            print(format.indent(test, '    '))
-            print('EXPECTED (order does not matter):')
-            print(format.indent(expected, '    '))
-            print('OUTPUT:')
-            print(format.indent(result, '    '))
-            print()
-            print("Please manually check if your solution's output is correct.")
-            return False
+            test, expected, actual = self._use_sqlite_cli(env)
+            print(format.indent(test, 'sqlite> '))
+            print(actual)
+            try:
+                self._diff_output(expected, actual)
+                return True
+            except interpreter.ConsoleException:
+                return False
         else:
             print("ERROR: could not run sqlite3.")
             print("Tests will not pass, but you can still submit your assignment.")
@@ -105,7 +100,9 @@ class SqliteConsole(interpreter.Console):
             actual = [e.exception_type]
         else:
             actual = self.format_rows(cursor)
+        self._diff_output(expected, actual)
 
+    def _diff_output(self, expected, actual):
         if expected != 'Error':
             expected = set(expected.split('\n'))
         if expected != actual:

--- a/client/sources/ok_test/sqlite.py
+++ b/client/sources/ok_test/sqlite.py
@@ -105,6 +105,13 @@ class SqliteConsole(interpreter.Console):
         self._diff_output(expected, actual)
 
     def _diff_output(self, expected, actual):
+        """Raises an interpreter.ConsoleException if expected and actual output
+        don't match.
+
+        PARAMETERS:
+        expected -- str; may be multiple lines
+        actual   -- str; may be multiple lines
+        """
         expected = expected.split('\n')
         actual = actual.split('\n')
 
@@ -198,14 +205,14 @@ class SqliteConsole(interpreter.Console):
         """Print rows from the given sqlite cursor, formatted with pipes "|".
 
         RETURNS:
-        set; set of rows (formatted as strings with pipes "|" to delimit columns)
+        str; sqlite output (formatted as strings with pipes "|" to delimit columns)
         """
-        rows = set()
+        rows = []
         for row in cursor:
             row = '|'.join(map(str, row))
-            rows.add(row)
+            rows.append(row)
             print(row)
-        return rows
+        return '\n'.join(rows)
 
     def evaluate_dot(self, code):
         """Performs dot-command expansion on the given code.

--- a/client/sources/ok_test/sqlite.py
+++ b/client/sources/ok_test/sqlite.py
@@ -263,4 +263,4 @@ class SqliteSuite(doctest.DoctestSuite):
 
     def __init__(self, verbose, interactive, timeout=None, **fields):
         super().__init__(verbose, interactive, timeout, **fields)
-        self.console.ordered = 'ordered' in fields and fields['ordered']
+        self.console.ordered = fields.get('ordered', False)

--- a/client/sources/ok_test/sqlite.py
+++ b/client/sources/ok_test/sqlite.py
@@ -46,7 +46,7 @@ class SqliteConsole(interpreter.Console):
                    PATH=os.getcwd() + os.pathsep + os.environ["PATH"])
         if self._has_sqlite_cli(env):
             test, expected, actual = self._use_sqlite_cli(env)
-            print(format.indent(test, 'sqlite> '))
+            print(format.indent(test, 'sqlite> '))  # TODO: show test with prompt
             print(actual)
             try:
                 self._diff_output(expected, actual)

--- a/client/sources/ok_test/sqlite.py
+++ b/client/sources/ok_test/sqlite.py
@@ -115,11 +115,12 @@ class SqliteConsole(interpreter.Console):
         expected = expected.split('\n')
         actual = actual.split('\n')
 
-        if not self.ordered:
-            expected = set(expected)
-            actual = set(actual)
+        if self.ordered:
+            correct = expected == actual
+        else:
+            correct = sorted(expected) == sorted(actual)
 
-        if expected != actual:
+        if not correct:
             print()
             error_msg = '# Error: expected'
             if self.ordered:

--- a/client/sources/ok_test/sqlite.py
+++ b/client/sources/ok_test/sqlite.py
@@ -267,6 +267,7 @@ class SqliteConsole(interpreter.Console):
 
 class SqliteSuite(doctest.DoctestSuite):
     console_type = SqliteConsole
+    # TODO: Ordered should be a property of cases, not entire suites.
     ordered = core.Boolean(default=False)
 
     def __init__(self, verbose, interactive, timeout=None, **fields):

--- a/demo/sqlite/tests/q1.py
+++ b/demo/sqlite/tests/q1.py
@@ -4,6 +4,7 @@ test = {
   'suites': [
     {
       'type': 'sqlite',
+      'ordered': False,
       'setup': r"""
       sqlite> .read hw1.sql
       """,

--- a/env/pyvenv.cfg
+++ b/env/pyvenv.cfg
@@ -1,3 +1,0 @@
-home = /usr/local/bin
-include-system-site-packages = false
-version = 3.4.2


### PR DESCRIPTION
Before:
```
TEST:
    .read lab12.sql
    SELECT * FROM obedience LIMIT 10;
EXPECTED (order does not matter):
    7|Image 1
    7|Image 2
    Choose this option instead.|Image 2
    7|Image 5
    Choose this option instead.|Image 5
    7|Image 5
    7|Image 2
    7|Image 4
    I'm a rebel|Image 4
    YOLO!|Image 5
OUTPUT:
    7|Image 1
    7|Image 2
    Choose this option instead.|Image 2
    7|Image 5
    Choose this option instead.|Image 5
    7|Image 5
    7|Image 2
    7|Image 4
    I'm a rebel|Image 4
    YOLO!|Image 5

Please manually check if your solution's output is correct.
```

After:
```
sqlite> .read lab12.sql
sqlite> SELECT * FROM obedience LIMIT 10;
7|Image 1
7|Image 2
Choose this option instead.|Image 2
7|Image 5
Choose this option instead.|Image 5
7|Image 5
7|Image 2
7|Image 4
I'm a rebel|Image 4
YOLO!|Image 5
```