### PR TITLE
Resolve authentication issues*

### DIFF
--- a/client/exceptions.py
+++ b/client/exceptions.py
@@ -3,6 +3,9 @@
 class OkException(BaseException):
     """Base exception class for OK."""
 
+class AuthenticationException(OkException):
+    """Exceptions related to authentication."""
+
 class ProtocolException(OkException):
     """Exceptions related to protocol errors."""
 

--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+
+from client import exceptions
+
 from .sanction import Client
 from urllib.parse import urlparse, parse_qs
 import http.server
@@ -23,18 +26,15 @@ SERVER = 'http://ok-server.appspot.com'
 
 def pick_free_port():
     import socket
-    port_guess = 7777
-    while port_guess < 65535:
-        try:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.bind(('localhost', port_guess))
-        except Exception as e: # Something went wrong with the binding
-            port_guess += 1
-            continue
-        finally:
-            s.close()
-        
-        return port_guess
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.bind(('localhost', 0)) # find an open port
+    except OSError as e:
+        print('Unable to find an open port for authentication.')
+        raise exceptions.AuthenticationException(e)
+    addr, port = s.getsockname()
+    s.close()
+    return port
 
 REDIRECT_PORT = pick_free_port()
 REDIRECT_URI = "http://%s:%u/" % (REDIRECT_HOST, REDIRECT_PORT)


### PR DESCRIPTION
A small but significant number of students have issues with finding a free port when authenticating.

![](https://d1b10bmlvqabco.cloudfront.net/attach/id52tzq2i7yfx/idrikt7hrs43v/ihftk65ai8ho/Screen_Shot_20151125_at_9.47.12_PM.png)

I don't know how to reproduce this issue, so I'm not 100% sure if this PR will help, although the student that provided the above screenshot was able to find an open port with `s.bind(('localhost', 0))`.

I'm also not sure if looking for an open port is always necessary -- it seems that this should only be happening when authentication actually happens.