### PR TITLE
do not use sqlite3 module, update socket timeout

### DIFF
--- a/client/__init__.py
+++ b/client/__init__.py
@@ -1,4 +1,4 @@
-__version__ = 'v1.4.8'
+__version__ = 'v1.4.9'
 FILE_NAME = 'ok'
 
 import os

--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -99,9 +99,9 @@ def main():
         exit(0)
     elif args.update:
         print("Current version: {}".format(client.__version__))
-        software_update.check_version(args.server, client.__version__,
-                                      client.FILE_NAME, timeout=10)
-        exit(0)
+        did_update = software_update.check_version(
+                args.server, client.__version__, client.FILE_NAME, timeout=10)
+        exit(not did_update) # exit with error if ok failed to update
 
     assign = None
     try:

--- a/client/protocols/backup.py
+++ b/client/protocols/backup.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 class BackupProtocol(models.Protocol):
 
     # Timeouts are specified in seconds.
-    SHORT_TIMEOUT = 1
+    SHORT_TIMEOUT = 2
 
     RETRY_LIMIT = 5
     BACKUP_FILE = ".ok_messages"

--- a/client/sources/ok_test/__init__.py
+++ b/client/sources/ok_test/__init__.py
@@ -47,4 +47,3 @@ def load(file, parameter, assign):
                                     assign.cmd_args.timeout, **test)}
     except ex.SerializeException:
         raise ex.LoadingException('Cannot load OK test {}'.format(file))
-

--- a/client/sources/ok_test/sqlite.py
+++ b/client/sources/ok_test/sqlite.py
@@ -140,11 +140,12 @@ class SqliteConsole(interpreter.Console):
         bool; True if able to import the sqlite3 module and the binding version
         is at least self.VERSION; False otherwise.
         """
-        try:
-            self.sqlite3 = importlib.import_module(self.MODULE)
-        except ImportError:
-            return False
-        return self.sqlite3.sqlite_version_info >= self.VERSION
+        return False # Hotfix to prevent segfaults (See Issue 140)
+        # try:
+        #     self.sqlite3 = importlib.import_module(self.MODULE)
+        # except ImportError:
+        #     return False
+        # return self.sqlite3.sqlite_version_info >= self.VERSION
 
     def _has_sqlite_cli(self, env):
         """Checks if the command "sqlite3" is executable with the given

--- a/client/utils/software_update.py
+++ b/client/utils/software_update.py
@@ -3,12 +3,12 @@ import logging
 import os
 import urllib.error
 import urllib.request
+from socket import error as socket_error
 
 log = logging.getLogger(__name__)
 
-# TODO(sumukh): does software update require ssl?
 VERSION_ENDPOINT = 'https://{server}/api/v1/version'
-TIMEOUT = 1  # seconds
+TIMEOUT = 5  # seconds
 
 def check_version(server, version, filename, timeout=TIMEOUT):
     """Check for the latest version of OK and update accordingly."""
@@ -22,8 +22,9 @@ def check_version(server, version, filename, timeout=TIMEOUT):
     try:
         request = urllib.request.Request(address)
         response = urllib.request.urlopen(request, timeout=TIMEOUT)
-    except (urllib.error.HTTPError, urllib.error.URLError) as e:
+    except (urllib.error.HTTPError, urllib.error.URLError, socket_error) as e:
         print('Network error when checking for updates.')
+        print('Current OK version: %s', version)
         log.warning('Network error when checking version from %s: %s', address,
                     str(e), stack_info=True)
         return False
@@ -83,4 +84,3 @@ def _write_zip(zip_name, zip_contents):
     with open(zip_name, 'wb') as f:
         f.write(zip_contents)
         os.fsync(f)
-

--- a/client/utils/software_update.py
+++ b/client/utils/software_update.py
@@ -8,9 +8,9 @@ from socket import error as socket_error
 log = logging.getLogger(__name__)
 
 VERSION_ENDPOINT = 'https://{server}/api/v1/version'
-TIMEOUT = 5  # seconds
+SHORT_TIMEOUT = 3  # seconds
 
-def check_version(server, version, filename, timeout=TIMEOUT):
+def check_version(server, version, filename, timeout=SHORT_TIMEOUT):
     """Check for the latest version of OK and update accordingly."""
 
     address = VERSION_ENDPOINT.format(server=server)
@@ -21,10 +21,9 @@ def check_version(server, version, filename, timeout=TIMEOUT):
 
     try:
         request = urllib.request.Request(address)
-        response = urllib.request.urlopen(request, timeout=TIMEOUT)
+        response = urllib.request.urlopen(request, timeout=timeout)
     except (urllib.error.HTTPError, urllib.error.URLError, socket_error) as e:
         print('Network error when checking for updates.')
-        print('Current OK version: %s', version)
         log.warning('Network error when checking version from %s: %s', address,
                     str(e), stack_info=True)
         return False
@@ -46,8 +45,8 @@ def check_version(server, version, filename, timeout=TIMEOUT):
 
     try:
         request = urllib.request.Request(download_link)
-        response = urllib.request.urlopen(request, timeout=TIMEOUT)
-    except urllib.error.HTTPError as e:
+        response = urllib.request.urlopen(request, timeout=timeout)
+    except (urllib.error.HTTPError, urllib.error.URLError, socket_error) as e:
         print('Error when downloading new version of OK')
         log.warning('Error when downloading new version of OK: %s', str(e),
                     stack_info=True)


### PR DESCRIPTION
Change log: 
- Hotfix for sqlite3 module (on multiple withs?) See #140 
- Resolve #139 by catching all socket errors
- Longer timeouts for force updates (and normal updates as well) 

I will try to also include a fix for the socket timeout issue (#139) so future upgrades won't have issues. 
 
Merging & Publishing now since a lot of students are running into this issue. 