### PR TITLE
Use subprocess timeout for SQL

### DIFF
--- a/client/sources/ok_test/sqlite.py
+++ b/client/sources/ok_test/sqlite.py
@@ -33,7 +33,10 @@ class SqliteConsole(interpreter.Console):
         env = dict(os.environ,
                    PATH=os.getcwd() + os.pathsep + os.environ['PATH'])
         if self._has_sqlite_cli(env):
-            test, expected, actual = self._use_sqlite_cli(env)
+            try:
+                test, expected, actual = self._use_sqlite_cli(env)
+            except interpreter.ConsoleException:
+                return False
             print(format.indent(test, 'sqlite> '))  # TODO: show test with prompt
             print(actual)
             try:

--- a/client/sources/ok_test/sqlite.py
+++ b/client/sources/ok_test/sqlite.py
@@ -137,7 +137,12 @@ class SqliteConsole(interpreter.Console):
                                     stdout=subprocess.PIPE,
                                     stderr=subprocess.PIPE,
                                     env=env)
-        result, error = process.communicate(test)
+        try:
+            result, error = process.communicate(test, timeout=self.timeout)
+        except subprocess.TimeoutExpired as e:
+            process.kill()
+            print('# Error: evaluation exceeded {} seconds.'.format(self.timeout))
+            raise interpreter.ConsoleException(exceptions.Timeout(self.timeout))
         return test, '\n'.join(expected), (error + '\n' + result).strip()
 
 class SqliteSuite(doctest.DoctestSuite):

--- a/demo/doctest/config.ok
+++ b/demo/doctest/config.ok
@@ -6,7 +6,8 @@
     ],
     "tests": {
         "hw1.py:square": "doctest",
-        "hw1.py:double": "doctest"
+        "hw1.py:double": "doctest",
+        "hw1.py:forever": "doctest"
     },
     "default_tests": [
         "square"

--- a/demo/doctest/hw1.py
+++ b/demo/doctest/hw1.py
@@ -27,3 +27,11 @@ def double(x):
     """
     return x # Incorrect
 
+def forever():
+    """
+    >>> forever()
+    1
+    """
+    while True:
+        pass
+    return 1

--- a/demo/sqlite/tests/q3.py
+++ b/demo/sqlite/tests/q3.py
@@ -1,0 +1,25 @@
+test = {
+  'name': 'Question 3',
+  'points': 2,
+  'suites': [
+    {
+      'type': 'sqlite',
+      'ordered': False,
+      'setup': r"""
+      """,
+      'cases': [
+        {
+          'code': r"""
+          sqlite> with
+             ...>   ints(n) as (
+             ...>   select 1 union
+             ...>   select n+1 from ints
+             ...>  )
+             ...> select n from ints order by n;
+          1
+          """,
+        },
+      ],
+    }
+  ]
+}


### PR DESCRIPTION
I haven't tested that this correctly terminates the sqlite subprocess when it takes too long.

This should be merged after #146. Resolves #140.