### PR TITLE
Add programmatic API for grading

### DIFF
--- a/client/cli/lock.py
+++ b/client/cli/lock.py
@@ -1,5 +1,5 @@
 from client import exceptions as ex
-from client.cli.common import assignment
+from client.api import assignment
 from client.cli.common import messages
 from client.protocols import lock
 import argparse
@@ -28,7 +28,7 @@ def main():
     args.interactive = False
 
     try:
-        assign = assignment.load_config(args.config, args)
+        assign = assignment.load_assignment(args.config, args)
         assign.load()
 
         msgs = messages.Messages()

--- a/client/cli/lock.py
+++ b/client/cli/lock.py
@@ -29,7 +29,6 @@ def main():
 
     try:
         assign = assignment.load_assignment(args.config, args)
-        assign.load()
 
         msgs = messages.Messages()
 

--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -1,7 +1,7 @@
 """This file is responsible for coordinating all of OK's protocols."""
 
 from client import exceptions as ex
-from client.cli.common import assignment
+from client.api import assignment
 from client.cli.common import messages
 from client.utils import auth
 from client.utils import output
@@ -23,7 +23,7 @@ CLIENT_ROOT = os.path.dirname(client.__file__)
 # Command-line Interface #
 ##########################
 
-def parse_input():
+def parse_input(command_input=None):
     """Parses command line input."""
     parser = argparse.ArgumentParser(
         description=__doc__,
@@ -85,7 +85,10 @@ def parse_input():
     parser.add_argument('--update', action='store_true',
                         help="checks and performs software update then exits")
 
-    return parser.parse_args()
+    if command_input is None:
+        return parser.parse_args()
+    else:
+        return parser.parse_args(command_input)
 
 def main():
     """Run all relevant aspects of ok.py."""
@@ -109,8 +112,7 @@ def main():
             auth.authenticate(True)
 
         # Instantiating assignment
-        assign = assignment.load_config(args.config, args)
-        assign.load()
+        assign = assignment.load_assignment(args.config, args)
 
         if args.tests:
             print('Available tests:')

--- a/client/cli/publish.py
+++ b/client/cli/publish.py
@@ -17,6 +17,7 @@ REQUIRED_FILES = [
 ]
 REQUIRED_FOLDERS = [
     'utils',
+    'api'
 ]
 COMMAND_LINE = [
     'ok',

--- a/client/cli/test.py
+++ b/client/cli/test.py
@@ -24,7 +24,6 @@ def main():
 
     try:
         assign = assignment.load_assignment(args.config, args)
-        assign.load()
 
         msgs = messages.Messages()
 

--- a/client/cli/test.py
+++ b/client/cli/test.py
@@ -1,6 +1,6 @@
 from client import exceptions as ex
 from client.cli import ok
-from client.cli.common import assignment
+from client.api import assignment
 from client.cli.common import messages
 from client.protocols import grading
 from client.protocols import scoring
@@ -23,7 +23,7 @@ def main():
     log.debug(args)
 
     try:
-        assign = assignment.load_config(args.config, args)
+        assign = assignment.load_assignment(args.config, args)
         assign.load()
 
         msgs = messages.Messages()

--- a/client/protocols/grading.py
+++ b/client/protocols/grading.py
@@ -30,45 +30,49 @@ class GradingProtocol(models.Protocol):
         """
         if self.args.score or self.args.export or self.args.unlock or self.args.restore:
             return
+        grade(self.assignment.specified_tests, messages, verbose=self.args.verbose)
 
-        format.print_line('~')
-        print('Running tests')
-        print()
-        passed = 0
-        failed = 0
-        locked = 0
 
-        analytics = {}
-        # check if analytics info is in messages
-        if 'analytics' in messages:
-            started = messages['analytics']['started']
+def grade(questions, messages, env=None, verbose=True):
+    format.print_line('~')
+    print('Running tests')
+    print()
+    passed = 0
+    failed = 0
+    locked = 0
+
+    analytics = {}
+    # Check if analytics info is in messages.
+    if 'analytics' in messages:
+        started = messages['analytics']['started']
+    else:
+        started = None
+
+    # The environment in which to run the tests.
+    for test in questions:
+        # run test if the question is not detected, or question detected and started
+        if (started is None
+            or test.name not in started
+            or started[test.name]):
+
+            log.info('Running tests for {}'.format(test.name))
+            results = test.run(env)
+            passed += results['passed']
+            failed += results['failed']
+            locked += results['locked']
+            analytics[test.name] = results
         else:
-            started = None
+            print('It looks like you haven\'t started {}. Skipping the tests.'.format(test.name))
+            print()
 
-        for test in self.assignment.specified_tests:
-            # run test if the question is not detected, or question detected and started
-            if (started is None
-                or test.name not in started
-                or started[test.name]):
+        if not verbose and (failed > 0 or locked > 0):
+            # Stop at the first failed test
+            break
 
-                log.info('Running tests for {}'.format(test.name))
-                results = test.run()
-                passed += results['passed']
-                failed += results['failed']
-                locked += results['locked']
-                analytics[test.name] = results
-            else:
-                print('It looks like you haven\'t started {}. Skipping the tests.'.format(test.name))
-                print()
+    format.print_progress_bar('Test summary', passed, failed, locked,
+                              verbose=verbose)
+    print()
 
-            if not self.args.verbose and (failed > 0 or locked > 0):
-                # Stop at the first failed test
-                break
-
-        format.print_progress_bar('Test summary', passed, failed, locked,
-                                  verbose=self.args.verbose)
-        print()
-
-        messages['grading'] = analytics
+    messages['grading'] = analytics
 
 protocol = GradingProtocol

--- a/client/sources/common/interpreter.py
+++ b/client/sources/common/interpreter.py
@@ -5,15 +5,6 @@ from client.sources.common import models
 import re
 import textwrap
 
-# TODO(albert): come up with a better cross-platform readline solution.
-try:
-    import readline
-    assert hasattr(readline, 'clear_history')
-    assert hasattr(readline, 'add_history')
-    HAS_READLINE = True
-except (ImportError, AssertionError):
-    HAS_READLINE = False
-
 class CodeCase(models.Case):
     """TestCase for doctest-style Python tests."""
 
@@ -172,7 +163,6 @@ class Console(object):
         setup    -- str; raw setup code
         teardown -- str; raw teardown code
         """
-        self.clear_history()
         self._setup = textwrap.dedent(setup).split('\n')
         self._code = code
         self._teardown = textwrap.dedent(teardown).split('\n')
@@ -240,7 +230,6 @@ class Console(object):
                 if line:
                     print(line)
                 line = self._strip_prompt(line)
-                self.add_history(line)
                 current.append(line)
             elif isinstance(line, CodeAnswer):
                 assert len(current) > 0, 'Answer without a prompt'
@@ -281,17 +270,6 @@ class Console(object):
             return line[len(self.PS2):]
         return line
 
-    ######################
-    # History management #
-    ######################
-
-    def add_history(self, line):
-        if HAS_READLINE and line:
-            readline.add_history(line)
-
-    def clear_history(self):
-        if HAS_READLINE:
-            readline.clear_history()
 
 class CodeAnswer(object):
     status_re = re.compile(r'^#\s*(.+?):\s*(.*)\s*$')

--- a/client/sources/common/models.py
+++ b/client/sources/common/models.py
@@ -7,8 +7,12 @@ class Test(core.Serializable):
     points = core.Float()
     partner = core.String(optional=True)
 
-    def run(self):
-        """Subclasses should override this method to run tests."""
+    def run(self, env):
+        """Subclasses should override this method to run tests.
+
+        NOTE: env is intended only for use with the programmatic API for
+        Python OK tests.
+        """
         raise NotImplementedError
 
     def score(self):

--- a/client/sources/common/pyconsole.py
+++ b/client/sources/common/pyconsole.py
@@ -12,6 +12,10 @@ class PythonConsole(interpreter.Console):
     PS1 = '>>> '
     PS2 = '... '
 
+    def __init__(self, verbose, interactive, timeout=None):
+        self._original_frame = {}
+        super().__init__(verbose, interactive, timeout)
+
     def load(self, code, setup='', teardown=''):
         """Prepares a set of setup, test, and teardown code to be
         run in the console.
@@ -23,7 +27,10 @@ class PythonConsole(interpreter.Console):
         teardown -- str; raw teardown code
         """
         super().load(code, setup, teardown)
-        self._frame = {}
+        self._frame = self._original_frame.copy()
+
+    def load_env(self, env):
+        self._original_frame = env
 
     def interact(self):
         """Opens up an interactive session with the current state of

--- a/client/sources/doctest/models.py
+++ b/client/sources/doctest/models.py
@@ -63,8 +63,11 @@ class Doctest(models.Test):
         self.case = interpreter.CodeCase(self.console, module,
                                              code='\n'.join(code))
 
-    def run(self):
+    def run(self, env):
         """Runs the suites associated with this doctest.
+
+        NOTE: env is intended only for use with the programmatic API to support
+        Python OK tests. It is not used here.
 
         RETURNS:
         bool; True if the doctest completely passes, False otherwise.

--- a/client/sources/ok_test/models.py
+++ b/client/sources/ok_test/models.py
@@ -34,8 +34,11 @@ class OkTest(models.Test):
             self.suites[i] = self.suite_map[suite['type']](
                     self.verbose, self.interactive, self.timeout, **suite)
 
-    def run(self):
+    def run(self, env):
         """Runs the suites associated with this OK test.
+
+        NOTE: env is intended only for use with the programmatic API to support
+        Python OK tests. For that reason, it is only passed to DoctestSuites.
 
         RETURNS:
         dict; the results for this test, in the form
@@ -47,7 +50,12 @@ class OkTest(models.Test):
         """
         passed, failed, locked = 0, 0, 0
         for i, suite in enumerate(self.suites):
-            results = suite.run(self.name, i + 1)
+            if hasattr(suite, 'doctest_suite_flag'):
+                # A hack that allows programmatic API users to plumb a custom
+                # environment through to Python tests.
+                results = suite.run(self.name, i + 1, env)
+            else:
+                results = suite.run(self.name, i + 1)
 
             passed += results['passed']
             failed += results['failed']

--- a/client/sources/scheme_test/models.py
+++ b/client/sources/scheme_test/models.py
@@ -36,8 +36,11 @@ class SchemeTest(models.Test):
         self.file_contents = file_contents
         self.timeout = timeout
 
-    def run(self):
+    def run(self, env):
         """Runs the suites associated with this doctest.
+
+        NOTE: env is intended only for use with the programmatic API to support
+        Python OK tests. It is not used here.
 
         RETURNS:
         bool; True if the doctest completely passes, False otherwise.

--- a/demo/ok_test/tests/q2.py
+++ b/demo/ok_test/tests/q2.py
@@ -31,7 +31,7 @@ test = {
         {
           'code': r"""
           >>> double(-4)
-          8
+          -8
           # explanation: doubling a negative number
           """,
           'hidden': False

--- a/tests/sources/doctest/models_test.py
+++ b/tests/sources/doctest/models_test.py
@@ -73,7 +73,7 @@ class DoctestTest(unittest.TestCase):
             'passed': 1,
             'failed': 0,
             'locked': 0,
-        }, test.run())
+        }, test.run(None))
 
     def testConstructor_printThenReturn(self):
         test = self.makeDoctest("""
@@ -88,7 +88,7 @@ class DoctestTest(unittest.TestCase):
             'passed': 1,
             'failed': 0,
             'locked': 0,
-        }, test.run())
+        }, test.run(None))
 
     def testConstructor_printNoEndCharThenReturn(self):
         test = self.makeDoctest("""
@@ -102,7 +102,7 @@ class DoctestTest(unittest.TestCase):
             'passed': 1,
             'failed': 0,
             'locked': 0,
-        }, test.run())
+        }, test.run(None))
 
     def testConstructor_invalidIndentationInconsistencies(self):
         # TODO(albert): test not passing
@@ -131,7 +131,7 @@ class DoctestTest(unittest.TestCase):
             'passed': 1,
             'failed': 0,
             'locked': 0,
-        }, test.run())
+        }, test.run(None))
 
     def testRun_partialFail(self):
         test = self.makeDoctest("""
@@ -144,7 +144,7 @@ class DoctestTest(unittest.TestCase):
             'passed': 0,
             'failed': 1,
             'locked': 0,
-        }, test.run())
+        }, test.run(None))
 
     def testRun_completeFail(self):
         test = self.makeDoctest("""
@@ -157,7 +157,7 @@ class DoctestTest(unittest.TestCase):
             'passed': 0,
             'failed': 1,
             'locked': 0,
-        }, test.run())
+        }, test.run(None))
 
     def testRun_solitaryPS1(self):
         test = self.makeDoctest("""
@@ -171,7 +171,7 @@ class DoctestTest(unittest.TestCase):
             'passed': 0,
             'failed': 1,
             'locked': 0,
-        }, test.run())
+        }, test.run(None))
 
     def testRun_solitaryPS2(self):
         test = self.makeDoctest("""
@@ -185,7 +185,7 @@ class DoctestTest(unittest.TestCase):
             'passed': 1,
             'failed': 0,
             'locked': 0,
-        }, test.run())
+        }, test.run(None))
 
 
     def testScore_completePass(self):

--- a/tests/sources/ok_test/doctest_test.py
+++ b/tests/sources/ok_test/doctest_test.py
@@ -21,7 +21,7 @@ class DoctestSuiteTest(unittest.TestCase):
             'passed': passed,
             'locked': locked,
             'failed': failed,
-        }, test.run(self.TEST_NAME, self.SUITE_NUMBER))
+        }, test.run(self.TEST_NAME, self.SUITE_NUMBER, None))
 
     def testConstructor_basicCases(self):
         try:

--- a/tests/sources/ok_test/models_test.py
+++ b/tests/sources/ok_test/models_test.py
@@ -45,9 +45,9 @@ class OkTest(unittest.TestCase):
             'passed': passed,
             'failed': failed,
             'locked': locked,
-        }, test.run())
-        self.mockSuite1.return_value.run.assert_called_with(self.NAME, 1)
-        self.mockSuite2.return_value.run.assert_called_with(self.NAME, 2)
+        }, test.run(None))
+        self.mockSuite1.return_value.run.assert_called_with(self.NAME, 1, None)
+        self.mockSuite2.return_value.run.assert_called_with(self.NAME, 2, None)
 
     def callsScore(self, score):
         test = self.makeTest(suites=[
@@ -125,7 +125,7 @@ class OkTest(unittest.TestCase):
             'passed': 0,
             'failed': 0,
             'locked': 0,
-        }, test.run())
+        }, test.run(None))
 
     def testRun_correctResults(self):
         self.mockSuite1.return_value.run.return_value = {


### PR DESCRIPTION
Resolves #135 . @papajohn @SamLau95

Usage:

```python
# Assuming the 'ok' binary is in sys.path
>>> from client.api.assignment import load_assignment
>>> assign = load_assignment('hw1.ok')
>>> # setup environment for tests
>>> results = assign.grade('q1')
>>> results
{'passed': 0, 'failed': 5, 'locked': 0}
>>> # students write some code to change the environment
>>> assign.grade('q1')
{'passed': 5, 'failed': 0, 'locked': 0}
```

Notes:

* `grade` takes a keyword argument `env` that is a `dict` representing the environment in which to execute the tests.
* If `env` is not specified, OK will use the environment of `__main__`. This is **not** necessarily the caller of `grade`. For example,

```python
def fn():
    x = 4
    assign.grade('q1')  # Will not have access to x
```

* The 'ok' binary has to be available on `sys.path`. You can either add 'ok' to PYTHONPATH or dynamically add it to `sys.path` at runtime.

**Implementation detail**: Getting this to work was more of a hack than an actual solution. The current OK architecture is heavily dependent on the assumption that OK is a terminal command; this limits good development of a programmatic API. If you ever want to develop the programmatic API more, I suggest redesigning OK to get around this limitation.