### PR TITLE
Catch authentication errors

### DIFF
--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -130,6 +130,9 @@ def main():
     except ex.LoadingException as e:
         log.warning('Assignment could not load', exc_info=True)
         print('Error loading assignment: ' + str(e))
+    except ex.AuthenticationException as e:
+        log.warning('Authentication exception occurred', exc_info=True)
+        print('Authentication error: {0}'.format(e))
     except ex.OkException as e:
         log.warning('General OK exception occurred', exc_info=True)
         print('Error: ' + str(e))

--- a/client/exceptions.py
+++ b/client/exceptions.py
@@ -1,13 +1,17 @@
 """Client exceptions."""
 
+
 class OkException(BaseException):
     """Base exception class for OK."""
+
 
 class AuthenticationException(OkException):
     """Exceptions related to authentication."""
 
+
 class ProtocolException(OkException):
     """Exceptions related to protocol errors."""
+
 
 # TODO(albert): extend from a base class designed for student bugs.
 class Timeout(OkException):
@@ -24,9 +28,10 @@ class Timeout(OkException):
         self.timeout = timeout
         self.message = self._message
 
+
 class LoadingException(OkException):
     """Exception related to loading assignments."""
 
+
 class SerializeException(LoadingException):
     """Exceptions related to de/serialization."""
-

--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -163,13 +163,13 @@ def authenticate(force=False):
                 code = qs['code'][0]
             except KeyError:
                 message = qs.get('error', 'Unknown')
-                log.info("No auth code provided {}".format(message))
+                log.warning("No auth code provided {}".format(message))
 
                 done = True
                 self.send_response(400)
                 self.send_header("Content-type", "text/html")
                 self.end_headers()
-                # TODO : Send error page HTML
+                self.wfile.write(bytes(failure_page(message), "utf-8"))
                 return
 
             access_token, refresh_token, expires_in = _make_code_post(code)
@@ -198,6 +198,19 @@ def success_page(server, email):
     data = urlopen(API).read().decode("utf-8")
     return success_auth(success_courses(email, data, server))
 
+def failure_page(error):
+    html = partial_nocourse_html
+    title = 'Authentication Error'
+    byline = 'Error: {}'.format(error)
+    status = 'We could not authenticate you.'
+    head = '<style>{0}</style>'.format(red_css)
+    return auth_html.format(
+        site=SERVER,
+        status=status,
+        courses=html,
+        byline=byline,
+        title=title,
+        head=head)
 
 def success_courses(email, response, server):
     """Generates HTML for individual courses"""

--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -11,9 +11,9 @@ from urllib.request import urlopen
 import webbrowser
 
 from client.exceptions import AuthenticationException
-from .html import auth_html, partial_course_html, partial_nocourse_html, \
-                  red_css
-from .sanction import Client
+from client.utils.html import auth_html, partial_course_html, \
+                              partial_nocourse_html, red_css
+from client.utils.sanction import Client
 
 import logging
 


### PR DESCRIPTION
Hides the tracebacks and prints a more user-friendly message when authentication fails under different scenarios (authorization code not received, access token is None). Addresses #152.