### PR TITLE
Stores auth token in persistent config directory

### DIFF
--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -26,6 +26,7 @@ CLIENT_ID = \
 # See: https://developers.google.com/accounts/docs/OAuth2InstalledApp
 CLIENT_SECRET = 'zGY9okExIBnompFTWcBmOZo4'
 
+
 def get_config_directory():
     if sys.platform == 'win32':
         return os.path.expanduser('~') + '\\AppData\\Local\\ok\\'
@@ -35,13 +36,14 @@ def create_config_directory():
     cfg_dir = get_config_directory()
     if not os.path.exists(cfg_dir):
         os.makedirs(cfg_dir)
-    
+
     
 REFRESH_FILE = get_config_directory() + "auth_refresh"
 REDIRECT_HOST = "localhost"
 TIMEOUT = 10
 
 SERVER = 'http://ok-server.appspot.com'
+
 
 def pick_free_port():
     import socket
@@ -95,7 +97,7 @@ def update_storage(access_token, expires_in, refresh_token):
     if not (access_token and expires_in and refresh_token):
         raise AuthenticationException(
             "Authentication failed and returned an empty token.")
-    
+
     cur_time = int(time.time())
     create_config_directory()
     with open(REFRESH_FILE, 'wb') as fp:

--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -19,17 +19,29 @@ import logging
 
 log = logging.getLogger(__name__)
 
+
 CLIENT_ID = \
     '931757735585-vb3p8g53a442iktc4nkv5q8cbjrtuonv.apps.googleusercontent.com'
 # The client secret in an installed application isn't a secret.
 # See: https://developers.google.com/accounts/docs/OAuth2InstalledApp
 CLIENT_SECRET = 'zGY9okExIBnompFTWcBmOZo4'
-REFRESH_FILE = '.ok_refresh'
+
+def get_config_directory():
+    if sys.platform == 'win32':
+        return os.path.expanduser('~') + '\\AppData\\Local\\ok\\'
+    return os.path.expanduser('~') + '/.config/ok/'
+    
+def create_config_directory():
+    cfg_dir = get_config_directory()
+    if not os.path.exists(cfg_dir):
+        os.makedirs(cfg_dir)
+    
+    
+REFRESH_FILE = get_config_directory() + "auth_refresh"
 REDIRECT_HOST = "localhost"
 TIMEOUT = 10
 
 SERVER = 'http://ok-server.appspot.com'
-
 
 def pick_free_port():
     import socket
@@ -68,6 +80,7 @@ def make_refresh_post(refresh_token):
 
 
 def get_storage():
+    create_config_directory()
     with open(REFRESH_FILE, 'rb') as fp:
         storage = pickle.load(fp)
 
@@ -82,8 +95,9 @@ def update_storage(access_token, expires_in, refresh_token):
     if not (access_token and expires_in and refresh_token):
         raise AuthenticationException(
             "Authentication failed and returned an empty token.")
-
+    
     cur_time = int(time.time())
+    create_config_directory()
     with open(REFRESH_FILE, 'wb') as fp:
         pickle.dump({
             'access_token': access_token,

--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -19,7 +19,6 @@ import logging
 
 log = logging.getLogger(__name__)
 
-
 CLIENT_ID = \
     '931757735585-vb3p8g53a442iktc4nkv5q8cbjrtuonv.apps.googleusercontent.com'
 # The client secret in an installed application isn't a secret.
@@ -28,8 +27,6 @@ CLIENT_SECRET = 'zGY9okExIBnompFTWcBmOZo4'
 
 
 def get_config_directory():
-    if sys.platform == 'win32':
-        return os.path.expanduser('~') + '\\AppData\\Local\\ok\\'
     return os.path.expanduser('~') + '/.config/ok/'
     
 def create_config_directory():

--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -25,17 +25,9 @@ CLIENT_ID = \
 # See: https://developers.google.com/accounts/docs/OAuth2InstalledApp
 CLIENT_SECRET = 'zGY9okExIBnompFTWcBmOZo4'
 
-
-def get_config_directory():
-    return os.path.expanduser('~') + '/.config/ok/'
+CONFIG_DIRECTORY = os.path.join(os.path.expanduser('~'), '.config', 'ok')
     
-def create_config_directory():
-    cfg_dir = get_config_directory()
-    if not os.path.exists(cfg_dir):
-        os.makedirs(cfg_dir)
-
-    
-REFRESH_FILE = get_config_directory() + "auth_refresh"
+REFRESH_FILE = os.path.join(CONFIG_DIRECTORY, "auth_refresh")
 REDIRECT_HOST = "localhost"
 TIMEOUT = 10
 
@@ -76,6 +68,12 @@ def make_refresh_post(refresh_token):
     params = {"grant_type": "refresh_token"}
     client.request_token(refresh_token=refresh_token, **params)
     return client.access_token, client.expires_in
+
+
+def create_config_directory():
+    cfg_dir = get_config_directory()
+    if not os.path.exists(cfg_dir):
+        os.makedirs(cfg_dir)
 
 
 def get_storage():

--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -71,9 +71,8 @@ def make_refresh_post(refresh_token):
 
 
 def create_config_directory():
-    cfg_dir = get_config_directory()
-    if not os.path.exists(cfg_dir):
-        os.makedirs(cfg_dir)
+    if not os.path.exists(CONFIG_DIRECTORY):
+        os.makedirs(CONFIG_DIRECTORY)
 
 
 def get_storage():


### PR DESCRIPTION
This resolves #157. On Unix, the auth token is now stored in `~/.config/ok/auth_refresh` while on Windows it's stored in `C:\Users\<user>\AppData\Local\ok\auth_refresh`.

I've tested this on Linux. Someone else should test it on Windows.