### PR TITLE
Fix Scoring Protocol 

### DIFF
--- a/client/sources/ok_test/doctest.py
+++ b/client/sources/ok_test/doctest.py
@@ -30,7 +30,7 @@ class DoctestSuite(models.Suite):
             self.cases[i] = interpreter.CodeCase(self.console, self.setup,
                                                  self.teardown, **case)
 
-    def run(self, test_name, suite_number, env):
+    def run(self, test_name, suite_number, env=None):
         """Runs test for the doctest suite.
 
         PARAMETERS:


### PR DESCRIPTION
It seems like `env` expects a None value 
>         env          -- dict; environment in which to run tests. If None, an
                     empty dictionary is used instead.

Making None be the default value for env in `DoctestSuite` fixes the scoring protocol

Old error when running the scoring protocol: 
```
Traceback (most recent call last):
  File "ok/__main__.py", line 9, in <module>
  File "ok/client/cli/ok.py", line 132, in main
  File "ok/client/protocols/scoring.py", line 51, in run
  File "ok/client/sources/ok_test/models.py", line 99, in score
TypeError: run() missing 1 required positional argument: 'env'
```