### PR TITLE
Fix ok-lock NameError

### DIFF
--- a/client/cli/lock.py
+++ b/client/cli/lock.py
@@ -4,7 +4,10 @@ from client.cli.common import messages
 from client.protocols import lock
 import argparse
 import client
+import logging
 import os.path
+
+log = logging.getLogger(__name__)
 
 CLIENT_ROOT = os.path.dirname(client.__file__)
 


### PR DESCRIPTION
Before, if `ok-lock` raised an exception, we'd get
```
$ ok-lock
Traceback (most recent call last):
  File "/Users/knrafto/code/berkeley-cs61a/env/lib/python3.4/site-packages/client/cli/lock.py", line 31, in main
    assign = assignment.load_assignment(args.config, args)
  File "/Users/knrafto/code/berkeley-cs61a/env/lib/python3.4/site-packages/client/api/assignment.py", line 19, in load_assignment
    config = _get_config(filepath)
  File "/Users/knrafto/code/berkeley-cs61a/env/lib/python3.4/site-packages/client/api/assignment.py", line 37, in _get_config
    raise ex.LoadingException('No .ok configuration file found')
client.exceptions.LoadingException: No .ok configuration file found

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/knrafto/code/berkeley-cs61a/env/bin/ok-lock", line 11, in <module>
    sys.exit(main())
  File "/Users/knrafto/code/berkeley-cs61a/env/lib/python3.4/site-packages/client/cli/lock.py", line 37, in main
    log.warning('Assignment could not instantiate', exc_info=True)
NameError: name 'log' is not defined
```