### PR TITLE
Perform atomic test dumps

### DIFF
--- a/client/sources/ok_test/models.py
+++ b/client/sources/ok_test/models.py
@@ -170,7 +170,7 @@ class OkTest(models.Test):
         # Use an atomic rename operation to prevent test corruption
 
         with open(test_tmp, 'w', encoding='utf-8') as f:
-            f.write('test = ' + json)
+            f.write('test = {}\n'.format(json))
 
         # Should silently replace the file if the tests are in the right format
 

--- a/client/sources/ok_test/models.py
+++ b/client/sources/ok_test/models.py
@@ -167,13 +167,10 @@ class OkTest(models.Test):
         json = format.prettyjson(self.to_json())
         test_tmp = "{}.tmp".format(self.file)
 
-        # Use an atomic rename operation to prevent test corruption
-
         with open(test_tmp, 'w', encoding='utf-8') as f:
             f.write('test = {}\n'.format(json))
 
-        # Should silently replace the file if the tests are in the right format
-
+        # Use an atomic rename operation to prevent test corruption
         os.replace(test_tmp, self.file)
 
     @property

--- a/client/sources/ok_test/models.py
+++ b/client/sources/ok_test/models.py
@@ -3,10 +3,12 @@ from client.sources.common import core
 from client.sources.common import models
 from client.utils import format
 from client.utils import output
+import os
 
 ##########
 # Models #
 ##########
+
 
 class OkTest(models.Test):
     suites = core.List()
@@ -111,7 +113,7 @@ class OkTest(models.Test):
 
     def unlock(self, interact):
         total_cases = len([case for suite in self.suites
-                                for case in suite.cases])
+                           for case in suite.cases])
         for suite_num, suite in enumerate(self.suites):
             for case_num, case in enumerate(suite.cases):
                 case_id = '{} > Suite {} > Case {}'.format(
@@ -123,7 +125,7 @@ class OkTest(models.Test):
                 print()
                 total_cases -= 1
 
-                if case.locked != True:
+                if case.locked is not True:
                     print('-- Already unlocked --')
                     print()
                     continue
@@ -148,9 +150,9 @@ class OkTest(models.Test):
                 elif case.locked == core.NoValue:
                     case.lock(hash_fn)
                     print(message + 'locking')
-                elif case.locked == False:
+                elif case.locked is False:
                     print(message + 'leaving unlocked')
-                elif case.locked == True:
+                elif case.locked is True:
                     print(message + 'already unlocked')
             if not suite.cases:
                 self.suites.remove(suite)
@@ -163,12 +165,21 @@ class OkTest(models.Test):
         # directory may be left in a corrupted state.
         # TODO(albert): might need to delete obsolete test files too.
         json = format.prettyjson(self.to_json())
-        with open(self.file, 'w', encoding='utf-8') as f:
+        test_tmp = "{}.tmp".format(self.file)
+
+        # Use an atomic rename operation to prevent test corruption
+
+        with open(test_tmp, 'w', encoding='utf-8') as f:
             f.write('test = ' + json)
+
+        # Should silently replace the file if the tests are in the right format
+
+        os.replace(test_tmp, self.file)
 
     @property
     def unique_id_prefix(self):
         return self.assignment_name + '\n' + self.name
+
 
 class Suite(core.Serializable):
     type = core.String()
@@ -222,4 +233,3 @@ class Suite(core.Serializable):
         output.remove_log(log_id)
 
         return success, output_log
-


### PR DESCRIPTION
This is just a quick and dirty fix in regards to #134. We write to a temporary file (non-atomic) and replace the existing test file with our temp file, so even if the client is interrupted the test cases won't get corrupted. Note that this only works on Unix systems; there's no way to guarantee an atomic file write on Windows, so I suggest we start looking into other ways to prevent this situation from even taking place.

1. Disable interrupts during test dumps. This is probably the best solution, and I'll look into implementing this.
2. Instead of modifying the tests, we can write to a separate file that contains unlocked test data. Note that this won't solve the issue of corruption, but it's an easier fix (delete the corrupted tests) than re-downloading the archive just to copy one test over.