### PR TITLE
Do not prompt for hints on every attempt

### DIFF
--- a/client/__init__.py
+++ b/client/__init__.py
@@ -1,4 +1,4 @@
-__version__ = 'v1.5.6'
+__version__ = 'v1.5.7'
 FILE_NAME = 'ok'
 
 import os

--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -57,8 +57,12 @@ def parse_input(command_input=None):
     parser.add_argument('--timeout', type=int, default=10,
                         help="set the timeout duration for running tests")
 
+    # Guidance and hinting
     parser.add_argument('--guidance', action='store_true',
                         help="display guidance messages")
+    parser.add_argument('--no-hints', action='store_true',
+                        help="do not prompt for hints")
+
     # Submission Export
     parser.add_argument('--export', action='store_true',
                         help="Downloads all submissions for the current assignment")
@@ -87,7 +91,7 @@ def parse_input(command_input=None):
                         help="turns off software updating")
     parser.add_argument('--update', action='store_true',
                         help="checks and performs software update then exits")
-    
+
     if command_input is None:
         return parser.parse_args()
     else:
@@ -98,11 +102,11 @@ def main():
     args = parse_input()
 
     log.setLevel(logging.DEBUG if args.debug else logging.ERROR)
-    
+
     # Checking user's Python bit version
     bit_v = (8 * struct.calcsize("P"))
     log.debug("Python bit version: {}".format(bit_v))
-    
+
     log.debug(args)
 
     if args.version:

--- a/client/protocols/hinting.py
+++ b/client/protocols/hinting.py
@@ -34,6 +34,7 @@ class HintingProtocol(protocol_models.Protocol):
     HINT_ENDPOINT = 'api/hints'
     SMALL_EFFORT = 5
     LARGE_EFFORT = 8
+    WAIT_ATTEMPTS = 5
 
     def run(self, messages):
         """Determine if a student is elgible to recieve a hint. Based on their
@@ -50,6 +51,10 @@ class HintingProtocol(protocol_models.Protocol):
             return
         if 'file_contents' not in messages:
             log.info('File Contents needed to generate hints')
+            return
+
+        if self.args.no_hints:
+            messages['hinting'] = {'disabled': 'user'}
             return
 
         messages['hinting'] = {}
@@ -84,7 +89,14 @@ class HintingProtocol(protocol_models.Protocol):
                          question, stats['attempts'], stats['solved'])
                 hint_info['elgible'] = False
             else:
-                hint_info['elgible'] = not stats['solved']
+                # Only prompt every WAIT_ATTEMPTS attempts to avoid annoying user
+                if stats['attempts'] % self.WAIT_ATTEMPTS != 0:
+                    hint_info['disabled'] = 'timer'
+                    hint_info['elgible'] = False
+                    log.info('Waiting for %d more attempts before prompting',
+                             stats['attempts'] % self.WAIT_ATTEMPTS)
+                else:
+                    hint_info['elgible'] = not stats['solved']
 
             if not hint_info['elgible']:
                 continue


### PR DESCRIPTION
Multiple students have asked for a way to turn hints off because having it ask on every run of ok can be annoying. 

This PR makes it ask at most every 5 attempts and also includes the `--no-hints` CLI flag to completely disable hints. 