### PR TITLE
Catch File Not Found Errors for Guidance

### DIFF
--- a/client/__init__.py
+++ b/client/__init__.py
@@ -1,4 +1,4 @@
-__version__ = 'v1.6.0'
+__version__ = 'v1.6.1'
 
 FILE_NAME = 'ok'
 

--- a/client/utils/guidance.py
+++ b/client/utils/guidance.py
@@ -81,7 +81,7 @@ class Guidance:
             if not self.validate_json():
                 raise ValueError("JSON did not validate")
             self.guidance_json = self.guidance_json['db']
-        except (IOError, ValueError):
+        except (IOError, ValueError, FileNotFoundError):
             log.warning("Failed to read .ok_guidance file.", exc_info=True)
             self.load_error = True
         log.debug("Guidance loaded with status: %s", not self.load_error)

--- a/client/utils/guidance.py
+++ b/client/utils/guidance.py
@@ -81,7 +81,7 @@ class Guidance:
             if not self.validate_json():
                 raise ValueError("JSON did not validate")
             self.guidance_json = self.guidance_json['db']
-        except (IOError, ValueError, FileNotFoundError):
+        except (OSError, IOError, ValueError):
             log.warning("Failed to read .ok_guidance file.", exc_info=True)
             self.load_error = True
         log.debug("Guidance loaded with status: %s", not self.load_error)


### PR DESCRIPTION
`FileNotFoundError` is 3.3+ so we'll catch `OSError` instead. 