### PR TITLE
Improve Auth Error Handling  (--get-token, error messages)

### DIFF
--- a/client/__init__.py
+++ b/client/__init__.py
@@ -1,4 +1,4 @@
-__version__ = 'v1.6.5'
+__version__ = 'v1.6.6'
 
 FILE_NAME = 'ok'
 

--- a/client/protocols/backup.py
+++ b/client/protocols/backup.py
@@ -36,10 +36,10 @@ class BackupProtocol(models.Protocol):
         if not access_token:
             print("Not authenticated. Cannot send {} to server".format(action))
             self.dump_unsent_messages(message_list)
-
+            return
 
         response = self.send_all_messages(access_token, message_list)
-        prefix='http' if self.args.insecure else 'https'
+        prefix = 'http' if self.args.insecure else 'https'
         base_url = '{0}://{1}'.format(prefix, self.args.server) + '/{}/{}/{}'
 
         if isinstance(response, dict):
@@ -48,8 +48,8 @@ class BackupProtocol(models.Protocol):
 
             submission_type = 'submissions' if self.args.submit else 'backups'
             url = base_url.format(response['data']['assignment'],
-                        submission_type,
-                        response['data']['key'])
+                                  submission_type,
+                                  response['data']['key'])
 
             if self.args.submit or self.args.backup:
                 print('URL: {0}'.format(url))

--- a/client/protocols/backup.py
+++ b/client/protocols/backup.py
@@ -25,16 +25,22 @@ class BackupProtocol(models.Protocol):
         if self.args.local or self.args.export or self.args.restore:
             return
 
+        action = 'Submission' if self.args.submit else 'Backup'
+
         message_list = self.load_unsent_messages()
         message_list.append(messages)
 
         access_token = auth.authenticate(False)
         log.info('Authenticated with access token %s', access_token)
 
+        if not access_token:
+            print("Not authenticated. Cannot send {} to server".format(action))
+            self.dump_unsent_messages(message_list)
+
+
         response = self.send_all_messages(access_token, message_list)
         prefix='http' if self.args.insecure else 'https'
         base_url = '{0}://{1}'.format(prefix, self.args.server) + '/{}/{}/{}'
-        action = 'Submission' if self.args.submit else 'Backup'
 
         if isinstance(response, dict):
             print('{action} successful for user: {email}'.format(action=action,

--- a/client/protocols/unlock.py
+++ b/client/protocols/unlock.py
@@ -13,7 +13,6 @@ from client.utils import locking
 from datetime import datetime
 import logging
 import random
-import string
 
 log = logging.getLogger(__name__)
 

--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -30,11 +30,14 @@ CLIENT_SECRET = 'zGY9okExIBnompFTWcBmOZo4'
 CONFIG_DIRECTORY = os.path.join(os.path.expanduser('~'), '.config', 'ok')
 
 REFRESH_FILE = os.path.join(CONFIG_DIRECTORY, "auth_refresh")
-REDIRECT_HOST = "127.0.0.1"
-TIMEOUT = 10
 
+REDIRECT_HOST = "127.0.0.1"
+REDIRECT_PORT = 6165
+
+TIMEOUT = 10
 SERVER = 'https://ok.cs61a.org'
-DEFAULT_PORT = 6165
+INFO_ENDPOINT = "https://www.googleapis.com/oauth2/v1/userinfo?access_token={}"
+
 
 def pick_free_port(hostname=REDIRECT_HOST, port=0):
     """ Try to bind a port. Default=0 selects a free port. """
@@ -150,7 +153,7 @@ def authenticate(force=False):
 
     host_name = REDIRECT_HOST
     try:
-        port_number = pick_free_port(port=DEFAULT_PORT)
+        port_number = pick_free_port(port=REDIRECT_PORT)
     except AuthenticationException as e:
         # Could not bind to REDIRECT_HOST:0, try localhost instead
         host_name = 'localhost'
@@ -319,14 +322,13 @@ def pluralize(num, string):
     return str(num)+string+('s' if num != 1 else '')
 
 # Grabs the student's email through the access_token and returns it.
-
 def get_student_email(access_token):
     if access_token is None:
         return None
     try:
-        user_dic = json.loads(urlopen("https://www.googleapis.com/oauth2/v1/userinfo?access_token=" + \
-            access_token, timeout=1).read().decode("utf-8"))
-        user_email = user_dic["email"]
+        request = urlopen(INFO_ENDPOINT.format(access_token), timeout=3)
+        user_data = json.loads(request.read().decode("utf-8"))
+        user_email = user_data["email"]
     except IOError as e:
         user_email = None
     return user_email

--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -244,7 +244,7 @@ def authenticate(force=False):
 
 def success_page(server, email, access_token):
     """ Generate HTML for the auth page.
-        Fetchs courses and plug into templates.
+        Fetches courses and plug into templates.
     """
     API = server + '/api/v3/enrollment/{0}/?access_token={1}'.format(
         email, access_token)

--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -2,27 +2,26 @@
 
 import http.server
 
-import errno
 import json
 import os
 import pickle
-import sys
 import time
 from urllib.parse import urlparse, parse_qs
 from urllib.request import urlopen
 import webbrowser
 
 from client.exceptions import AuthenticationException
-from client.utils.html import auth_html, partial_course_html, \
-                              partial_nocourse_html, red_css
+from client.utils.html import (auth_html, partial_course_html,
+                               partial_nocourse_html, red_css)
 from client.utils.sanction import Client
 
 import logging
 
 log = logging.getLogger(__name__)
 
-CLIENT_ID = \
-    '931757735585-vb3p8g53a442iktc4nkv5q8cbjrtuonv.apps.googleusercontent.com'
+CLIENT_ID = ('931757735585-vb3p8g53a442iktc4nkv5q8cbjrtuonv'
+             '.apps.googleusercontent.com')
+
 # The client secret in an installed application isn't a secret.
 # See: https://developers.google.com/accounts/docs/OAuth2InstalledApp
 CLIENT_SECRET = 'zGY9okExIBnompFTWcBmOZo4'


### PR DESCRIPTION
Change: 
- Use 127.0.0.1 instead of localhost to resolve DNS/Network issues 
- Only get port when authenticating instead of always
- Use default 6165 (bonus points for figuring why its 6165)
- add --get-token flag
- better error handling (actual error pages), instead of just exceptions in the terminal 

Ideally someone could test this on linux & windows. 

Test Suite: 
- Auth with `--auth` 
- Auth with another process using the default port (`python3 -m http.server --bind 127.0.0.1 6165`) 
- Auth but you hit the deny button on the OAuth permissions screen 
