### PR TITLE
Insecure Updates

### DIFF
--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -118,7 +118,8 @@ def main():
     elif args.update:
         print("Current version: {}".format(client.__version__))
         did_update = software_update.check_version(
-                args.server, client.__version__, client.FILE_NAME, timeout=10)
+                args.server, client.__version__, client.FILE_NAME, timeout=10,
+                insecure=args.insecure)
         exit(not did_update)  # exit with error if ok failed to update
 
     if args.get_token:
@@ -164,7 +165,8 @@ def main():
         if not args.no_update:
             try:
                 software_update.check_version(args.server, client.__version__,
-                                              client.FILE_NAME)
+                                              client.FILE_NAME,
+                                              insecure=args.insecure)
             except KeyboardInterrupt:
                 pass
 

--- a/client/utils/software_update.py
+++ b/client/utils/software_update.py
@@ -7,14 +7,16 @@ from socket import error as socket_error
 
 log = logging.getLogger(__name__)
 
-VERSION_ENDPOINT = 'https://{server}/api/v3/version/ok-client'
+VERSION_ENDPOINT = '{protocol}://{server}/api/v3/version/ok-client'
 
 SHORT_TIMEOUT = 3  # seconds
 
-def check_version(server, version, filename, timeout=SHORT_TIMEOUT):
+def check_version(server, version, filename, timeout=SHORT_TIMEOUT,
+                  insecure=False):
     """Check for the latest version of OK and update accordingly."""
 
-    address = VERSION_ENDPOINT.format(server=server)
+    protocol = "http" if insecure else "https"
+    address = VERSION_ENDPOINT.format(protocol=protocol, server=server)
 
     print('Checking for software updates...')
     log.info('Existing OK version: %s', version)


### PR DESCRIPTION
Enables insecure updates (when the user uses `--insecure`) 

I'm somewhat hesitant to actually have this deployed because we are downloading executable files. The user is explicitly asking us to not use SSL though...

Alternatives: 
- Use the response from the OK when submitting/backing up (though this still doesn't resolve the security issue) 
- Hit a github API and get the most recent release. 
