### PR TITLE
Fix persistence "bug" when running multiple Logic suites.

### DIFF
--- a/client/__init__.py
+++ b/client/__init__.py
@@ -1,4 +1,4 @@
-__version__ = 'v1.6.13'
+__version__ = 'v1.6.14'
 
 FILE_NAME = 'ok'
 

--- a/client/sources/ok_test/logic.py
+++ b/client/sources/ok_test/logic.py
@@ -8,6 +8,7 @@ the following interface:
     logic.buffer_input()
     logic.read_line(code)
     logic.process_input(exp, env)
+    logic.facts
 """
 
 from client import exceptions
@@ -84,6 +85,15 @@ class LogicConsole(interpreter.Console):
         except ImportError as e:
             raise exceptions.ProtocolException('Could not import logic')
 
+    def _reset_logic(self):
+        """The Logic interpreter needs to be reset before running a suite.
+        All mutable global variables should be reset.
+        """
+        self.logic.facts[:] = []
+
 class LogicSuite(doctest.DoctestSuite):
     console_type = LogicConsole
 
+    def run(self, test_name, suite_number, env=None):
+        self.console._reset_logic()
+        return super().run(test_name, suite_number, env)


### PR DESCRIPTION
If `(load logic_file)` is run several times, the facts within that Logic file are appended to the global list of facts several times, resulting in duplicate facts and therefore duplicate outputs.

This PR resets the state of the Logic interpreter between suites by clearing the list of facts at the beginning of each suite run.