### PR TITLE
Revert "Warn and exit on 32 bit installations of Python"

### DIFF
--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -157,11 +157,6 @@ def main():
     # Checking user's Python bit version
     bit_v = (8 * struct.calcsize("P"))
     log.debug("Python {}bit".format(bit_v))
-    if not args.local and bit_v == 32:
-        #If they aren't running --local and on 32 warn and quit
-        print('We cannot authenticate you with a 32 bit version of Python. To '
-               'run locally use the --local flag')
-        exit(0)
 
     if args.version:
         print("okpy=={}".format(client.__version__))


### PR DESCRIPTION
Reverts Cal-CS-61A-Staff/ok-client#216

This causes issues for some who don't have trouble with 32 but python.