### PR TITLE
Add Python 3.6 to tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ install:
 cache:
   directories:
   - "$HOME/.cache/pip"
-  - lib/python3.2/site-packages
   - lib/python3.3/site-packages
   - lib/python3.4/site-packages
   - lib/python3.5/site-packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 install:
   - pip install -r requirements.txt
@@ -16,5 +17,6 @@ cache:
   - lib/python3.3/site-packages
   - lib/python3.4/site-packages
   - lib/python3.5/site-packages
+  - lib/python3.6/site-packages
 
 script: nosetests --with-coverage tests


### PR DESCRIPTION
We might want to think about deprecating 3.2 support. 