### PR TITLE
Use requests

### DIFF
--- a/client/protocols/collaborate.py
+++ b/client/protocols/collaborate.py
@@ -11,10 +11,7 @@ import os
 import sys
 import shutil
 
-import json
 import logging
-import urllib.error
-import urllib.request
 import platform
 import time
 
@@ -189,7 +186,6 @@ class CollaborateProtocol(models.Protocol):
 
     def send_messages(self, data, timeout=30, endpoint='/collab/start/'):
         """Send messages to server, along with user authentication."""
-        serialized_data = json.dumps(data).encode(encoding='utf-8')
         server = self.COLLAB_SERVER + endpoint
         prefix = 'http' if self.args.insecure else 'https'
         address = self.API_ENDPOINT.format(server=server, prefix=prefix)
@@ -198,15 +194,13 @@ class CollaborateProtocol(models.Protocol):
             'client_name': 'ok-client',
             'client_version': client.__version__,
         }
-        headers = {"Content-Type": "application/json"}
 
         log.info('Sending messages to %s', address)
         try:
-            r = requests.post(address, params=params, data=serialized_data,
-                              headers=headers, timeout=timeout)
+            r = requests.post(address, params=params, json=data, timeout=timeout)
             r.raise_for_status()
             return r.json()
-        except (requests.exceptions.RequestException, urllib.error.HTTPError, Exception) as ex:
+        except (requests.exceptions.RequestException, requests.exceptions.BaseHTTPError, Exception) as ex:
             message = '{}: {}'.format(ex.__class__.__name__, str(ex))
             log.warning(message)
             print("There was an error connecting to the server."

--- a/client/utils/guidance.py
+++ b/client/utils/guidance.py
@@ -5,7 +5,7 @@ import hashlib
 import json
 import logging
 import os
-from urllib.request import urlopen
+import requests
 log = logging.getLogger(__name__)
 
 """
@@ -335,8 +335,7 @@ class Guidance:
                               TG_SERVER_ENDING))
             try:
                 log.info("Accessing treatment server at %s", tg_url)
-                data = json.loads((urlopen(tg_url, timeout=1).read()
-                                                             .decode("utf-8")))
+                data = requests.get(tg_url, timeout=1).json()
             except IOError:
                 data = {"tg": -1}
                 log.warning("Failed to communicate to server", exc_info=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Client
 sanction==0.4.1
-requests==2.11.1
+requests==2.12.4
 
 # Tests
 nose==1.3.3


### PR DESCRIPTION
Resolves #232.

I removed all references to `urllib.request`. I tried to test everything manually as I changed them. Hopefully we'll have less SSL errors now that we use requests' certs.