### PR TITLE
Guidance Prompt for Explanation

### DIFF
--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -102,8 +102,8 @@ def parse_input(command_input=None):
 
     # Experiments
     experiment = parser.add_argument_group('experiment options')
-    experiment.add_argument('--no-hints', action='store_true',
-                        help="do not give hints")
+    experiment.add_argument('--no-experiments', action='store_true',
+                        help="do not run experimental features")
     experiment.add_argument('--hint', action='store_true',
                         help="give a hint (if available)")
     experiment.add_argument('--style', action='store_true',

--- a/client/protocols/hinting.py
+++ b/client/protocols/hinting.py
@@ -56,7 +56,7 @@ class HintingProtocol(protocol_models.Protocol):
             log.info('File Contents needed to generate hints')
             return
 
-        if self.args.no_hints:
+        if self.args.no_experiments:
             messages['hinting'] = {'disabled': 'user'}
             return
 

--- a/client/protocols/unlock.py
+++ b/client/protocols/unlock.py
@@ -69,6 +69,9 @@ class UnlockProtocol(models.Protocol):
             log.info('Unlocking test {}'.format(test.name))
             self.current_test = test.name
 
+            # Reset guidance explanation probability for every question
+            self.guidance_util.prompt_probability = 0.10
+
             try:
                 test.unlock(self.interact)
             except (KeyboardInterrupt, EOFError):

--- a/client/protocols/unlock.py
+++ b/client/protocols/unlock.py
@@ -163,7 +163,7 @@ class UnlockProtocol(models.Protocol):
                                                                      self.hash_key)
                 misU_count_dict, tg_id, printed_msg, rationale = guidance_data
             else:
-                rationale = self.guidance_util.prompt_with_prob(prob=1.0)
+                rationale = self.guidance_util.prompt_with_prob()
                 print("-- OK! --")
                 printed_msg = ["-- OK! --"]
 

--- a/client/protocols/unlock.py
+++ b/client/protocols/unlock.py
@@ -153,12 +153,14 @@ class UnlockProtocol(models.Protocol):
                 correct = True
             tg_id = -1
             misU_count_dict = {}
+            rationale = "Unknown"
 
             if not correct:
-                misU_count_dict, tg_id, printed_msg = self.guidance_util.show_guidance_msg(unique_id,input_lines,
-                    self.hash_key)
-
+                guidance_data = self.guidance_util.show_guidance_msg(unique_id, input_lines,
+                                                                     self.hash_key)
+                misU_count_dict, tg_id, printed_msg, rationale = guidance_data
             else:
+                rationale = self.guidance_util.prompt_with_prob()
                 print("-- OK! --")
                 printed_msg = ["-- OK! --"]
 
@@ -171,6 +173,7 @@ class UnlockProtocol(models.Protocol):
                 'answer': input_lines,
                 'correct': correct,
                 'treatment group id': tg_id,
+                'rationale': rationale,
                 'misU count': misU_count_dict,
                 'printed msg': printed_msg
             })

--- a/client/protocols/unlock.py
+++ b/client/protocols/unlock.py
@@ -70,7 +70,7 @@ class UnlockProtocol(models.Protocol):
             self.current_test = test.name
 
             # Reset guidance explanation probability for every question
-            self.guidance_util.prompt_probability = 0.10
+            self.guidance_util.prompt_probability = guidance.DEFAULT_PROMPT_PROBABILITY
 
             try:
                 test.unlock(self.interact)

--- a/client/protocols/unlock.py
+++ b/client/protocols/unlock.py
@@ -153,14 +153,14 @@ class UnlockProtocol(models.Protocol):
                 correct = True
             tg_id = -1
             misU_count_dict = {}
-            rationale = "Unknown"
+            rationale = "Unknown - Default Value"
 
             if not correct:
                 guidance_data = self.guidance_util.show_guidance_msg(unique_id, input_lines,
                                                                      self.hash_key)
                 misU_count_dict, tg_id, printed_msg, rationale = guidance_data
             else:
-                rationale = self.guidance_util.prompt_with_prob()
+                rationale = self.guidance_util.prompt_with_prob(prob=1.0)
                 print("-- OK! --")
                 printed_msg = ["-- OK! --"]
 

--- a/client/utils/guidance.py
+++ b/client/utils/guidance.py
@@ -56,6 +56,8 @@ CONFIRM_BLANK_EXPLANATION = """
 Are you sure you don't want to answer? Explaining your answer
 can improve your understanding of the question. (hit enter to skip)"""
 
+DEFAULT_PROMPT_PROBABILITY = 0.10
+
 # These lambda functions allow us to map from a certain type of misunderstanding to
 # the desired targeted guidance message we want to show.
 # lambda for control or treatment group where we want nothing to happen
@@ -77,7 +79,7 @@ class Guidance:
         an error when opening the JSON file, we flagged it as error.
         """
         self.tg_id = -1
-        self.prompt_probability = 0.10
+        self.prompt_probability = DEFAULT_PROMPT_PROBABILITY
         self.assignment = assignment
         if assignment:
             self.assignment_name = assignment.name.replace(" ", "")

--- a/client/utils/guidance.py
+++ b/client/utils/guidance.py
@@ -372,9 +372,10 @@ class Guidance:
 
     def prompt_with_prob(self, orig_response=None, prob=None):
         """Ask for rationale with a specific level of probability. """
-        if self.assignment.cmd_args.no_experiments:
-            log.info("Skipping prompt due to --no-experiments")
-            return "Skipped due to --no-experiments"
+        # Disable opt-out.
+        # if self.assignment.cmd_args.no_experiments:
+        #     log.info("Skipping prompt due to --no-experiments")
+        #     return "Skipped due to --no-experiments"
 
         if prob is None:
             prob = self.prompt_probability

--- a/client/utils/guidance.py
+++ b/client/utils/guidance.py
@@ -376,6 +376,9 @@ class Guidance:
         # if self.assignment.cmd_args.no_experiments:
         #     log.info("Skipping prompt due to --no-experiments")
         #     return "Skipped due to --no-experiments"
+        if hasattr(self.assignment, 'is_test'):
+            log.info("Skipping prompt due to test mode")
+            return "Test response"
 
         if prob is None:
             prob = self.prompt_probability

--- a/client/utils/guidance.py
+++ b/client/utils/guidance.py
@@ -287,7 +287,7 @@ class Guidance:
         if response in wa_lst_explain_responses:
             rationale = self.prompt_with_prob(orig_response=input_lines, prob=1.0)
         else:
-            rationale = 'Unavailable - not in watch list'
+            rationale = 'Response not in watch list'
 
         if len(msg_id_set) == 0:
             log.info("No messages to display.")
@@ -370,9 +370,9 @@ class Guidance:
 
     def prompt_with_prob(self, orig_response=None, prob=None):
         """Ask for rationale with a specific level of probability. """
-        if self.assignment.cmd_args.no_hints:
-            log.info("Skipping prompt due to --no-hints")
-            return "Skipped due to --no-hints"
+        if self.assignment.cmd_args.no_experiments:
+            log.info("Skipping prompt due to --no-experiments")
+            return "Skipped due to --no-experiments"
 
         if prob is None:
             prob = self.prompt_probability

--- a/client/utils/guidance.py
+++ b/client/utils/guidance.py
@@ -1,11 +1,16 @@
 from client.utils import auth
 from client.utils import assess_id_util
+from client.utils import prompt
+from client.utils import format
 
 import hashlib
 import json
 import logging
 import os
+import random
+
 import requests
+
 log = logging.getLogger(__name__)
 
 """
@@ -36,7 +41,7 @@ TG_SERVER_ENDING = "/unlock_tg"
 LOCAL_TG_FILE = "tests/tg.ok_tg"
 OK_GUIDANCE_FILE = "tests/.ok_guidance"
 GUIDANCE_DEFAULT_MSG = "-- Not quite. Try again! --"
-EMPTY_MISUCOUNT_TGID_PRNTEDMSG = ({}, -1, [])
+EMPTY_MISUCOUNT_TGID_PRNTEDMSG = ({}, -1, [], "Unknown Rationale")
 COUNT_FILE_PATH = "tests/misUcount.json"
 TG_CONTROL = 0
 # If student forces guidance messages to show, we will assign treatment
@@ -44,6 +49,12 @@ TG_CONTROL = 0
 GUIDANCE_FLAG_TG_NUMBER = 1
 # If set_tg() fails, we will default to this treatment group number
 TG_ERROR_VALUE = -1
+
+# Question prompt for misunderstanding recognition
+EXPLANTION_PROMPT = "To help CS61A provide better hints, explain your answer "
+CONFIRM_BLANK_EXPLANATION = """
+Are you sure you don't want to answer? Explaining your answer
+can improve your understanding of the question. (hit enter to skip)"""
 
 # These lambda functions allow us to map from a certain type of misunderstanding to
 # the desired targeted guidance message we want to show.
@@ -66,7 +77,7 @@ class Guidance:
         an error when opening the JSON file, we flagged it as error.
         """
         self.tg_id = -1
-
+        self.prompt_probability = 0.5
         self.assignment = assignment
         if assignment:
             self.assignment_name = assignment.name.replace(" ", "")
@@ -170,6 +181,7 @@ class Guidance:
         wa_count_threshold = self.guidance_json['wrongAnsThresh']
         wa_lst_assess_num = assess_dict_info['dictWA2LstAssessNum_WA']
         msg_id_set = set()
+        should_skip_propogation = self.tg_id == 3 or self.tg_id == 4
 
         answerDict, countData = self.get_misUdata()
         prev_responses = answerDict.get(shorten_unique_id, [])
@@ -206,12 +218,13 @@ class Guidance:
 
                 log.info("Has given %d previous responses in lst_assess_num", num_prev_responses)
 
-                # Increment countDict by the number of wrong answers seen
-                # for each tag assoicated with this wrong answer
-                increment = num_prev_responses
-                for misu in lst_mis_u:
-                    log.info("Updating the count of misu: %s by %s", misu, increment)
-                    countData[misu] = countData.get(misu, 0) + increment
+                if not should_skip_propogation:
+                    # Increment countDict by the number of wrong answers seen
+                    # for each tag assoicated with this wrong answerDict
+                    increment = num_prev_responses
+                    for misu in lst_mis_u:
+                        log.info("Updating the count of misu: %s by %s", misu, increment)
+                        countData[misu] = countData.get(misu, 0) + increment
 
                 for misu in lst_mis_u:
                     log.debug("Misu: %s has count %s", misu, countData[misu])
@@ -219,7 +232,7 @@ class Guidance:
                         msg_info = lambda_info_misu(wa_details, misu)
                         if msg_info:
                             msg_id_set.add(msg_info)
-            else:
+            elif not should_skip_propogation:
                 # Lookup the lst_mis_u of each wrong answer in the list of wrong
                 # answers related to the current wrong answer (lst_assess_num),
                 # using dictAssessNum2AssessId
@@ -268,13 +281,18 @@ class Guidance:
                             log.info("misu %s seen %s/%s times",
                                      misu, countData[misu], wa_count_threshold)
 
-
         self.save_misUdata(answerDict, countData)
+
+        wa_lst_explain_responses = assess_dict_info.get('lstWrongAnsWatch', [])
+        if response in wa_lst_explain_responses:
+            rationale = self.prompt_with_prob(orig_response=input_lines)
+        else:
+            rationale = 'Unavailable - not in watch list'
 
         if len(msg_id_set) == 0:
             log.info("No messages to display.")
             print(GUIDANCE_DEFAULT_MSG)
-            return (countData, self.tg_id, [])
+            return (countData, self.tg_id, [], rationale)
 
         print("\n-- Helpful Hint --")
 
@@ -290,7 +308,7 @@ class Guidance:
         print()
         print(GUIDANCE_DEFAULT_MSG)
 
-        return (countData, self.tg_id, printed_out_msgs)
+        return (countData, self.tg_id, printed_out_msgs, rationale)
 
     def get_misUdata(self):
         # Creates a new folder inside tests that stores the number of misU per
@@ -309,7 +327,7 @@ class Guidance:
     def save_misUdata(self, answerDict, countData):
         data = {
             "countData": countData,
-            "answerDict": answerDict
+            "answerDict": answerDict,
         }
         log.info("Attempting to save response/count dict")
         with open(self.current_working_dir + COUNT_FILE_PATH, "w") as f:
@@ -349,3 +367,25 @@ class Guidance:
 
         tg_file = open(self.current_working_dir + LOCAL_TG_FILE, 'r')
         self.tg_id = int(tg_file.read())
+
+    def prompt_with_prob(self, orig_response=None, prob=None):
+        """Ask for rationale with a specific level of probability. """
+        if self.assignment.cmd_args.no_hints:
+            log.info("Skipping prompt due to --no-hints")
+            return "Skipped due to --no-hints"
+
+        if prob is None:
+            prob = self.prompt_probability
+
+        if random.random() > prob:
+            log.info("Did not prompt for rationale: Insufficient Probability")
+            return "Did not prompt for rationale"
+        with format.block(style="-"):
+            rationale =  prompt.explanation_msg(EXPLANTION_PROMPT,
+                                short_msg=CONFIRM_BLANK_EXPLANATION)
+
+        # Reduce future prompt likelihood
+        self.prompt_probability = self.prompt_probability / 2
+
+        if orig_response:
+            print('Thanks! Your original response was: {}'.format('\n'.join(orig_response)))

--- a/client/utils/guidance.py
+++ b/client/utils/guidance.py
@@ -386,7 +386,7 @@ class Guidance:
 
         if prob is None:
             # Reduce future prompt likelihood
-            self.prompt_probability = self.prompt_probability / 2
+            self.prompt_probability = 0
         if orig_response:
             print('Thanks! Your original response was: {}'.format('\n'.join(orig_response)))
 

--- a/client/utils/guidance.py
+++ b/client/utils/guidance.py
@@ -77,7 +77,7 @@ class Guidance:
         an error when opening the JSON file, we flagged it as error.
         """
         self.tg_id = -1
-        self.prompt_probability = 0.5
+        self.prompt_probability = 0.10
         self.assignment = assignment
         if assignment:
             self.assignment_name = assignment.name.replace(" ", "")
@@ -285,7 +285,7 @@ class Guidance:
 
         wa_lst_explain_responses = assess_dict_info.get('lstWrongAnsWatch', [])
         if response in wa_lst_explain_responses:
-            rationale = self.prompt_with_prob(orig_response=input_lines)
+            rationale = self.prompt_with_prob(orig_response=input_lines, prob=1.0)
         else:
             rationale = 'Unavailable - not in watch list'
 
@@ -381,11 +381,13 @@ class Guidance:
             log.info("Did not prompt for rationale: Insufficient Probability")
             return "Did not prompt for rationale"
         with format.block(style="-"):
-            rationale =  prompt.explanation_msg(EXPLANTION_PROMPT,
+            rationale = prompt.explanation_msg(EXPLANTION_PROMPT,
                                 short_msg=CONFIRM_BLANK_EXPLANATION)
 
-        # Reduce future prompt likelihood
-        self.prompt_probability = self.prompt_probability / 2
-
+        if prob is None:
+            # Reduce future prompt likelihood
+            self.prompt_probability = self.prompt_probability / 2
         if orig_response:
             print('Thanks! Your original response was: {}'.format('\n'.join(orig_response)))
+
+        return rationale

--- a/client/utils/guidance.py
+++ b/client/utils/guidance.py
@@ -183,7 +183,7 @@ class Guidance:
         wa_count_threshold = self.guidance_json['wrongAnsThresh']
         wa_lst_assess_num = assess_dict_info['dictWA2LstAssessNum_WA']
         msg_id_set = set()
-        should_skip_propogation = self.tg_id == 3 or self.tg_id == 4
+        should_skip_propagation = self.tg_id == 3 or self.tg_id == 4
 
         answerDict, countData = self.get_misUdata()
         prev_responses = answerDict.get(shorten_unique_id, [])
@@ -220,7 +220,7 @@ class Guidance:
 
                 log.info("Has given %d previous responses in lst_assess_num", num_prev_responses)
 
-                if not should_skip_propogation:
+                if not should_skip_propagation:
                     # Increment countDict by the number of wrong answers seen
                     # for each tag assoicated with this wrong answerDict
                     increment = num_prev_responses
@@ -234,7 +234,7 @@ class Guidance:
                         msg_info = lambda_info_misu(wa_details, misu)
                         if msg_info:
                             msg_id_set.add(msg_info)
-            elif not should_skip_propogation:
+            elif not should_skip_propagation:
                 # Lookup the lst_mis_u of each wrong answer in the list of wrong
                 # answers related to the current wrong answer (lst_assess_num),
                 # using dictAssessNum2AssessId

--- a/client/utils/prompt.py
+++ b/client/utils/prompt.py
@@ -1,0 +1,35 @@
+import logging
+import sys
+
+log = logging.getLogger(__name__)
+
+def explanation_msg(message, short_limit=1, short_msg=None):
+    try:
+        response = None
+        short_responses = 0
+        while not response:
+            response = input("{}\nYour Response: ".format(message))
+            if not response or len(response) < 5:
+                response = ''
+                short_responses += 1
+                log.info("Got a short response. Current count at {}".format(short_responses))
+                # Do not ask more than SHORT_LIMIT to avoid annoying the user
+                if short_responses > short_limit:
+                    break
+                if short_msg is None:
+                    print("Please enter at least a sentence.")
+                else:
+                    print(short_msg)
+        return response
+    except KeyboardInterrupt:
+        # Hack for windows
+        try:
+            print("") # Second I/O will get KeyboardInterrupt
+            return 'KeyboardInterrupt'
+        except KeyboardInterrupt:
+            return 'KeyboardInterrupt'
+
+def confirm(message):
+    response = input("{} [yes/no]: ".format(message))
+    return response.lower() == "yes" or response.lower() == "y"
+

--- a/client/utils/prompt.py
+++ b/client/utils/prompt.py
@@ -8,7 +8,7 @@ def explanation_msg(message, short_limit=1, short_msg=None):
         response = None
         short_responses = 0
         while not response:
-            response = input("{}\nYour Response: ".format(message)).strip()
+            response = input("{}\nYour Response: ".format(message))
             if not response or len(response) < 5:
                 response = ''
                 short_responses += 1

--- a/client/utils/prompt.py
+++ b/client/utils/prompt.py
@@ -8,7 +8,7 @@ def explanation_msg(message, short_limit=1, short_msg=None):
         response = None
         short_responses = 0
         while not response:
-            response = input("{}\nYour Response: ".format(message))
+            response = input("{}\nYour Response: ".format(message)).strip()
             if not response or len(response) < 5:
                 response = ''
                 short_responses += 1

--- a/tests/protocols/unlock_test.py
+++ b/tests/protocols/unlock_test.py
@@ -11,6 +11,7 @@ class UnlockProtocolTest(unittest.TestCase):
     def setUp(self):
         self.cmd_args = mock.Mock()
         self.assignment = mock.Mock()
+        self.assignment.is_test = True
         self.proto = unlock.protocol(self.cmd_args, self.assignment)
 
     def testOnInteract_noTests(self):


### PR DESCRIPTION
This adds a feature to the unlocking guidance messages where we prompt students for an explanation of their answer. This allows the guidance researchers to understand _why_ students are leaving certain answers. It can also be useful for students to be able to explain their answers. 

The changes to provide the watchlist are tacked on to the existing guidance messages files and the collected responses goes into the unlocking message (just like the other guidance fields) 

Some details:
- There are treatment groups - this is handled by the old treatment code for the most part. 
- It asks only if the student answers is a watchlist or if they were randomly selected to answer their correct answer. 

Ship date: Shipping before first CS61A Lab this week (if the `.ok_guidance` file is updated) 