### PR TITLE
Retry expired logins in notebooks

### DIFF
--- a/client/__init__.py
+++ b/client/__init__.py
@@ -1,4 +1,4 @@
-__version__ = 'v1.9.4'
+__version__ = 'v1.9.5'
 
 FILE_NAME = 'ok'
 

--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -327,12 +327,13 @@ def get_info(assignment, access_token):
     response.raise_for_status()
     return response.json()['data']
 
-def display_student_email(assignment, access_token, warn=True):
+def display_student_email(assignment, access_token):
     try:
         email = get_info(assignment, access_token)['email']
         print('Successfully logged in as', email)
         return email
-    except:
+    except Exception:  # Do not catch KeyboardInterrupts
+        log.debug("Did not obtain email", exc_info=True)
         return None
 
 def get_student_email(assignment):

--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -203,7 +203,7 @@ def notebook_authenticate(assignment, force=False):
         access_token = perform_oauth(assignment, notebook_get_code)
 
     # Always display email
-    email = display_student_email(assignment, access_token, warn=True)
+    email = display_student_email(assignment, access_token)
     if email is None and not force:
         return notebook_authenticate(assignment, force=True)  # Token has expired
     elif email is None:


### PR DESCRIPTION
I'm not sure how I got into a situation where my token couldn't be refreshed - but if someone does we should have them auth again. 

![image](https://cloud.githubusercontent.com/assets/882381/22282177/a9b36dee-e28f-11e6-9973-594c169c38f9.png)

I only put it in the notebook code because it immediately accesses the email on every call to auth - unlike the normal auth flow. 
