### PR TITLE
Always load all protocols

### DIFF
--- a/client/api/assignment.py
+++ b/client/api/assignment.py
@@ -56,7 +56,7 @@ def _get_config(config):
 
 class Assignment(core.Serializable):
     name = core.String()
-    endpoint = core.String()
+    endpoint = core.String(optional=True, default='')
     src = core.List(type=str, optional=True)
     tests = core.Dict(keys=str, values=str, ordered=True)
     default_tests = core.List(type=str, optional=True)

--- a/client/api/assignment.py
+++ b/client/api/assignment.py
@@ -130,9 +130,9 @@ class Assignment(core.Serializable):
         "file_contents",
         "grading",
         "analytics",
-        "autostyle"
+        "autostyle",
         "collaborate",
-        "hinting"
+        "hinting",
         "lock",
         "scoring",
         "unlock",

--- a/client/api/assignment.py
+++ b/client/api/assignment.py
@@ -233,12 +233,9 @@ class Assignment(core.Serializable):
     def _load_protocols(self):
         log.info('Loading protocols')
         for proto in self._PROTOCOLS:
-            try:
-                module = importlib.import_module(self._PROTOCOL_PACKAGE + '.' + proto)
-                self.protocol_map[proto] = module.protocol(self.cmd_args, self)
-                log.info('Loaded protocol "{}"'.format(proto))
-            except ImportError:
-                log.debug('Skipping unknown protocol "{}"'.format(proto))
+            module = importlib.import_module(self._PROTOCOL_PACKAGE + '.' + proto)
+            self.protocol_map[proto] = module.protocol(self.cmd_args, self)
+            log.info('Loaded protocol "{}"'.format(proto))
 
     def _print_header(self):
         format.print_line('=')

--- a/client/api/assignment.py
+++ b/client/api/assignment.py
@@ -60,7 +60,8 @@ class Assignment(core.Serializable):
     src = core.List(type=str, optional=True)
     tests = core.Dict(keys=str, values=str, ordered=True)
     default_tests = core.List(type=str, optional=True)
-    protocols = core.List(type=str)
+    # ignored, for backwards-compatibility only
+    protocols = core.List(type=str, optional=True)
 
     ####################
     # Programmatic API #
@@ -112,6 +113,31 @@ class Assignment(core.Serializable):
 
     _TESTS_PACKAGE = 'client.sources'
     _PROTOCOL_PACKAGE = 'client.protocols'
+
+    # A list of all protocols that should be loaded. Order is important.
+    # Dependencies:
+    # analytics     -> grading
+    # autostyle     -> analytics, grading
+    # backup        -> all other protocols
+    # collaborate   -> file_contents, analytics
+    # file_contents -> none
+    # grading       -> none
+    # hinting       -> file_contents, analytics
+    # lock          -> none
+    # scoring       -> none
+    # unlock        -> none
+    _PROTOCOLS = [
+        "file_contents",
+        "grading",
+        "analytics",
+        "autostyle"
+        "collaborate",
+        "hinting"
+        "lock",
+        "scoring",
+        "unlock",
+        "backup",
+    ]
 
     def __init__(self, args, **fields):
         self.cmd_args = args
@@ -206,7 +232,7 @@ class Assignment(core.Serializable):
 
     def _load_protocols(self):
         log.info('Loading protocols')
-        for proto in self.protocols:
+        for proto in self._PROTOCOLS:
             try:
                 module = importlib.import_module(self._PROTOCOL_PACKAGE + '.' + proto)
                 self.protocol_map[proto] = module.protocol(self.cmd_args, self)

--- a/client/protocols/backup.py
+++ b/client/protocols/backup.py
@@ -20,6 +20,10 @@ class BackupProtocol(models.Protocol):
     REVISION_ENDPOINT = '{server}/api/v3/revision/'
 
     def run(self, messages):
+        if not self.assignment.endpoint:
+            log.info('No assignment endpoint, skipping backup')
+            return
+
         if self.args.local:
             print("Cannot backup when running ok with --local.")
             return

--- a/tests/api/assignment_test.py
+++ b/tests/api/assignment_test.py
@@ -354,7 +354,7 @@ class AssignmentTest(unittest.TestCase):
         self.mockImportModule.side_effect = import_module
         self.mockFindFiles.return_value = [self.FILE1]
 
-        self.makeAssignment()
+        self.assertRaises(ImportError, self.makeAssignment)
 
     def testConstructor_noProtocols(self):
         self.mockFindFiles.return_value = [self.FILE1]


### PR DESCRIPTION
From now on we'll ignore the list of protocols in `protocols`.