### PR TITLE
Remove partner scoring system

### DIFF
--- a/client/protocols/scoring.py
+++ b/client/protocols/scoring.py
@@ -63,8 +63,8 @@ def display_breakdown(scores, outfile):
 
     format.print_line('-')
     print('Point breakdown', file=outfile)
-    for name, (score, total) in scores.items():
-        print('    {}: {}/{}'.format(name, score, total), file=outfile)
+    for name, (score, max_score) in scores.items():
+        print('    {}: {}/{}'.format(name, score, max_score), file=outfile)
         total += score
     print(file=outfile)
 

--- a/client/protocols/scoring.py
+++ b/client/protocols/scoring.py
@@ -16,25 +16,14 @@ log = logging.getLogger(__name__)
 # Scoring Mechanism #
 #####################
 
-NO_PARTNER_NAME = 'Total'
-
 class ScoringProtocol(protocol_models.Protocol):
     """A Protocol that runs tests, formats results, and reports a student's
     score.
     """
     def run(self, messages, env=None):
-        """Score tests and print results
-
-        Tests are taken from self.assignment.specified_tests. Each test belongs
-        to a partner. If test.partner is omitted (i.e. core.NoValue), the score
-        for that test is added to every partner's score.
-
-        If there are no tests, the mapping will only contain one entry, mapping
-        "Total" -> 0 (total score).
-
-        If there are no partners specified by the tests, the mapping will only
-        contain one entry, mapping "Total" (partner) -> total score (float).
-        This assumes there is always at least one partner.
+        """Score tests and print results. Tests are taken from
+        self.assignment.specified_tests. A score breakdown by question and the
+        total score are both printed.
 
         ENV is used by the programatic API for Python doctests only.
         """
@@ -50,7 +39,6 @@ class ScoringProtocol(protocol_models.Protocol):
             assert isinstance(test, sources_models.Test), 'ScoringProtocol received invalid test'
 
             log.info('Scoring test {}'.format(test.name))
-            partner = test.partner if test.partner != core.NoValue else None
 
             # A hack that allows programmatic API users to plumb a custom
             # environment through to Python tests.
@@ -60,7 +48,7 @@ class ScoringProtocol(protocol_models.Protocol):
             else:
                 score = test.score()
 
-            raw_scores[test.name, partner] = (score, test.points)
+            raw_scores[test.name] = (score, test.points)
 
         messages['scoring'] = display_breakdown(raw_scores, self.args.score_out)
         print()
@@ -69,32 +57,19 @@ def display_breakdown(scores, outfile):
     """Writes the point breakdown to outfile given a dictionary of scores.
 
     RETURNS:
-    dict; maps partner (str) -> finalized score (float)
+    dict; 'Total' -> finalized score (float)
     """
-    partner_totals = {}
+    total = 0
 
     format.print_line('-')
     print('Point breakdown', file=outfile)
-    for (name, partner), (score, total) in scores.items():
+    for name, (score, total) in scores.items():
         print('    {}: {}/{}'.format(name, score, total), file=outfile)
-        partner_totals[partner] = partner_totals.get(partner, 0) + score
+        total += score
     print(file=outfile)
 
-    shared_points = partner_totals.get(None, 0)
-    if None in partner_totals:
-        del partner_totals[None]
-
-    finalized_scores = {}
     print('Score:', file=outfile)
-    if len(partner_totals) == 0:
-        print('    {}: {}'.format(NO_PARTNER_NAME, shared_points), file=outfile)
-        finalized_scores[NO_PARTNER_NAME] = shared_points
-    else:
-        for partner, score in sorted(partner_totals.items()):
-            print('    Partner {}: {}'.format(partner, score + shared_points),
-                  file=outfile)
-            finalized_scores[partner] = score + shared_points
-    outfile.flush()
-    return finalized_scores
+    print('    Total: {}'.format(total), file=outfile)
+    return {'Total': total}
 
 protocol = ScoringProtocol

--- a/tests/protocols/scoring_test.py
+++ b/tests/protocols/scoring_test.py
@@ -11,9 +11,6 @@ class ScoringProtocolTest(unittest.TestCase):
     SCORE1 = 2
     SCORE2 = 3
 
-    PARTNER1 = 'A'
-    PARTNER2 = 'B'
-
     def setUp(self):
         self.cmd_args = mock.Mock()
         self.cmd_args.score = True
@@ -49,30 +46,11 @@ class ScoringProtocolTest(unittest.TestCase):
     def testOnInteract_noTests(self):
         self.assignment.specified_tests = []
         self.assertEqual({
-            scoring.NO_PARTNER_NAME: 0,
+            'Total': 0,
         }, self.callRun())
 
     def testOnInteract_noSpecifiedPartners(self):
         messages = {}
         self.assertEqual({
-            scoring.NO_PARTNER_NAME: self.SCORE0 + self.SCORE1 + self.SCORE2
-        }, self.callRun())
-
-    def testOnInteract_specifiedPartners_noSharedPoints(self):
-        self.mockTest0.partner = self.PARTNER1
-        self.mockTest1.partner = self.PARTNER1
-        self.mockTest2.partner = self.PARTNER2
-        messages = {}
-        self.assertEqual({
-            self.PARTNER1: self.SCORE0 + self.SCORE1,
-            self.PARTNER2: self.SCORE2
-        }, self.callRun())
-
-    def testOnInteract_specifiedPartners_sharedPoints(self):
-        self.mockTest0.partner = self.PARTNER1
-        self.mockTest1.partner = self.PARTNER2
-        messages = {}
-        self.assertEqual({
-            self.PARTNER1: self.SCORE0 + self.SCORE2,
-            self.PARTNER2: self.SCORE1 + self.SCORE2
+            'Total': self.SCORE0 + self.SCORE1 + self.SCORE2
         }, self.callRun())

--- a/tests/protocols/scoring_test.py
+++ b/tests/protocols/scoring_test.py
@@ -8,7 +8,7 @@ import unittest
 
 class ScoringProtocolTest(unittest.TestCase):
     SCORE0 = 1
-    SCORE1 = 2
+    SCORE1 = 2.5
     SCORE2 = 3
 
     def setUp(self):


### PR DESCRIPTION
ok-client had the ability to score partners of a project differently. It was confusing and nobody currently uses it, so I'd rather remove it than document it