### PR TITLE
Emulate doctest exception handling

### DIFF
--- a/client/sources/common/interpreter.py
+++ b/client/sources/common/interpreter.py
@@ -249,10 +249,10 @@ class Console(object):
             detail = "{}: {}".format(e.exception_type, str(e.exception))
             actual = CodeAnswer(exception=True, exception_detail=detail.splitlines())
         else:
-            output = printed.splitlines()
             if value is not None:
                 print(self._output_fn(value))
-                output.append(self._output_fn(value))
+                printed += self._output_fn(value)
+            output = printed.splitlines()
             actual = CodeAnswer(output=output)
 
         if not self.skip_locked_cases and expected.locked:

--- a/client/sources/common/interpreter.py
+++ b/client/sources/common/interpreter.py
@@ -267,17 +267,17 @@ class Console(object):
                 return
 
         correct = (expected.exception == actual.exception
-            and expected.dump() == actual.dump())
+            and expected.output_lines() == actual.output_lines())
         correct_legacy_exception = (actual.exception
-            and actual.exception_type == expected.dump())
+            and [actual.exception_type] == expected.output_lines())
         if not correct and not correct_legacy_exception:
             print()
             print('# Error: expected')
             print('\n'.join('#     {}'.format(line)
-                            for line in expected.dump().splitlines()))
+                            for line in expected.output_lines()))
             print('# but got')
             print('\n'.join('#     {}'.format(line)
-                            for line in actual.dump().splitlines()))
+                            for line in actual.output_lines()))
             raise ConsoleException
 
     def _strip_prompt(self, line):
@@ -308,10 +308,8 @@ class CodeAnswer(object):
         self.exception_detail = exception_detail or []
 
     def dump(self):
-        if self.exception:
-            result = [self.EXCEPTION_HEADERS[0], '  ...'] + self.exception_detail
-        else:
-            result = list(self.output)
+        """Serialize a test case to a string."""
+        result = list(self.output_lines())
         if self.locked:
             result.append('# locked')
             if self.choices:
@@ -320,6 +318,15 @@ class CodeAnswer(object):
         if self.explanation:
             result.append('# explanation: ' + self.explanation)
         return '\n'.join(result)
+
+    def output_lines(self):
+        """Return a sequence of lines, suitable for printing or comparing
+        answers.
+        """
+        if self.exception:
+            return [self.EXCEPTION_HEADERS[0], '  ...'] + self.exception_detail
+        else:
+            return self.output
 
     def update(self, line):
         if self.exception:

--- a/client/sources/common/interpreter.py
+++ b/client/sources/common/interpreter.py
@@ -102,12 +102,12 @@ class CodeCase(models.Case):
         list; a processed sequence of lines corresponding to the input code.
         """
         processed_lines = []
-        for line in textwrap.dedent(code).split('\n'):
+        for line in textwrap.dedent(code).splitlines():
             if not line or line.startswith(PS1) or line.startswith(PS2):
                 processed_lines.append(line)
                 continue
 
-            assert len(processed_lines) > 0, 'code improperly formated: {}'.format(code)
+            assert len(processed_lines) > 0, 'code improperly formatted: {}'.format(code)
             if not isinstance(processed_lines[-1], CodeAnswer):
                 processed_lines.append(CodeAnswer())
             processed_lines[-1].update(line)
@@ -165,9 +165,9 @@ class Console(object):
         setup    -- str; raw setup code
         teardown -- str; raw teardown code
         """
-        self._setup = textwrap.dedent(setup).split('\n')
+        self._setup = textwrap.dedent(setup).splitlines()
         self._code = code
-        self._teardown = textwrap.dedent(teardown).split('\n')
+        self._teardown = textwrap.dedent(teardown).splitlines()
 
     def interpret(self):
         """Interprets the console on the loaded code.
@@ -223,7 +223,7 @@ class Console(object):
                     # Previous prompt ends when PS1 or a blank line occurs
                     try:
                         if compare_all:
-                            self._compare('', '\n'.join(current))
+                            self._compare(CodeAnswer(), '\n'.join(current))
                         else:
                             self.evaluate('\n'.join(current))
                     except ConsoleException:
@@ -236,7 +236,7 @@ class Console(object):
             elif isinstance(line, CodeAnswer):
                 assert len(current) > 0, 'Answer without a prompt'
                 try:
-                    self._compare('\n'.join(line.output), '\n'.join(current))
+                    self._compare(line, '\n'.join(current))
                 except ConsoleException:
                     return False
                 current = []
@@ -246,30 +246,28 @@ class Console(object):
         try:
             value, printed = self.evaluate(code)
         except ConsoleException as e:
-            actual = e.exception_type
+            detail = "{}: {}".format(e.exception_type, str(e.exception))
+            actual = CodeAnswer(exception=True, exception_detail=detail.splitlines())
         else:
+            output = printed.splitlines()
             if value is not None:
                 print(self._output_fn(value))
-                actual = (printed + self._output_fn(value)).strip()
-            else:
-                actual = printed.strip()
+                output.append(self._output_fn(value))
+            actual = CodeAnswer(output=output)
 
-        expected = expected.strip()
-
-        if not self.skip_locked_cases and expected != actual:
-            actual = locking.lock(self.hash_key, actual)
-            if expected != actual:
+        if not self.skip_locked_cases and expected.locked:
+            if '\n'.join(expected.output) != locking.lock(self.hash_key, actual.dump()):
                 print()
                 print("# Error: expected and actual results do not match")
                 raise ConsoleException
-        elif expected != actual:
+        elif expected.exception != actual.exception or expected.dump() != actual.dump():
             print()
             print('# Error: expected')
             print('\n'.join('#     {}'.format(line)
-                            for line in expected.split('\n')))
+                            for line in expected.dump().splitlines()))
             print('# but got')
             print('\n'.join('#     {}'.format(line)
-                            for line in actual.split('\n')))
+                            for line in actual.dump().splitlines()))
             raise ConsoleException
 
     def _strip_prompt(self, line):
@@ -284,14 +282,25 @@ class CodeAnswer(object):
     status_re = re.compile(r'^#\s*(.+?):\s*(.*)\s*$')
     locked_re = re.compile(r'^#\s*locked\s*$')
 
-    def __init__(self, output=None, choices=None, explanation='', locked=False):
+    EXCEPTION_HEADERS = [
+        'Traceback (most recent call last):',
+        'Traceback (innermost last):',
+    ]
+
+    def __init__(self, output=None, choices=None, explanation='', locked=False,
+                 exception=False, exception_detail=None):
         self.output = output or []
         self.choices = choices or []
         self.locked = locked
         self.explanation = explanation
+        self.exception = exception
+        self.exception_detail = exception_detail or []
 
     def dump(self):
-        result = list(self.output)
+        if self.exception:
+            result = [self.EXCEPTION_HEADERS[0], '  ...'] + self.exception_detail
+        else:
+            result = list(self.output)
         if self.locked:
             result.append('# locked')
             if self.choices:
@@ -302,18 +311,29 @@ class CodeAnswer(object):
         return '\n'.join(result)
 
     def update(self, line):
-        if self.locked_re.match(line):
-            self.locked = True
-            return
-        match = self.status_re.match(line)
-        if not match:
-            self.output.append(line)
-        elif match.group(1) == 'locked':
-            self.locked = True
-        elif match.group(1) == 'explanation':
-            self.explanation = match.group(2)
-        elif match.group(1) == 'choice':
-            self.choices.append(match.group(2))
+        if self.exception:
+            if not self.exception_detail and not (line and line[0].isalnum()):
+                # ignore indented or lines that start with non-alphanumeric
+                # characters
+                return
+            self.exception_detail.append(line)
+        else:
+            if not self.output and line in self.EXCEPTION_HEADERS:
+                # Exception header must be first
+                self.exception = True
+                return
+            if self.locked_re.match(line):
+                self.locked = True
+                return
+            match = self.status_re.match(line)
+            if not match:
+                self.output.append(line)
+            elif match.group(1) == 'locked':
+                self.locked = True
+            elif match.group(1) == 'explanation':
+                self.explanation = match.group(2)
+            elif match.group(1) == 'choice':
+                self.choices.append(match.group(2))
 
 
 class ConsoleException(Exception):
@@ -323,4 +343,3 @@ class ConsoleException(Exception):
             self.exception_type = exception_type
         else:
             self.exception_type = exception.__class__.__name__
-

--- a/client/utils/output.py
+++ b/client/utils/output.py
@@ -7,8 +7,8 @@ class _OutputLogger(object):
     """Custom logger for capturing and suppressing standard output."""
     # TODO(albert): logger should fully implement output stream.
 
-    def __init__(self):
-        self._current_stream = self._stdout = sys.stdout
+    def __init__(self, stdout=sys.stdout):
+        self._current_stream = self._stdout = stdout
         self._devnull = open(os.devnull, 'w')
         self._logs = {}
         self._num_logs = 0

--- a/demo/doctest/config.ok
+++ b/demo/doctest/config.ok
@@ -7,7 +7,8 @@
     "tests": {
         "hw1.py:square": "doctest",
         "hw1.py:double": "doctest",
-        "hw1.py:forever": "doctest"
+        "hw1.py:forever": "doctest",
+        "hw1.py:exception": "doctest"
     },
     "default_tests": [
         "square"

--- a/demo/doctest/hw1.py
+++ b/demo/doctest/hw1.py
@@ -35,3 +35,13 @@ def forever():
     while True:
         pass
     return 1
+
+def exception():
+    """
+    >>> exception()
+    Traceback (most recent call last):
+      ...
+    ValueError: hello
+    """
+    print('foo')
+    raise ValueError('hello')

--- a/demo/doctest/hw1.py
+++ b/demo/doctest/hw1.py
@@ -42,6 +42,8 @@ def exception():
     Traceback (most recent call last):
       ...
     ValueError: hello
+    >>> exception()
+    ValueError
     """
     print('foo')
     raise ValueError('hello')

--- a/demo/ok_test/tests/q1.py
+++ b/demo/ok_test/tests/q1.py
@@ -67,6 +67,10 @@ test = {
           'code': r"""
           >>> 1 / square(0)
           ZeroDivisionError
+          >>> square(1) / square(0)
+          Traceback (most recent call last):
+            ...
+          ZeroDivisionError: division by zero
           """,
           'hidden': True
         }

--- a/tests/sources/common/pyconsole_test.py
+++ b/tests/sources/common/pyconsole_test.py
@@ -40,10 +40,27 @@ class PythonConsoleTest(unittest.TestCase):
             7
             """)
 
+    def testPass_printMultipleLines(self):
+        self.calls_interpret(True,
+            """
+            >>> print('Hello,\\nworld!')
+            Hello,
+            world!
+            """)
+
     def testPass_expectException(self):
         self.calls_interpret(True,
             """
             >>> 1 / 0
+            Traceback (most recent call last):
+              ...
+            ZeroDivisionError: division by zero
+            """)
+
+    def testPass_printThenException(self):
+        self.calls_interpret(True,
+            """
+            >>> print('hello'); 1 / 0
             Traceback (most recent call last):
               ...
             ZeroDivisionError: division by zero
@@ -149,6 +166,16 @@ class PythonConsoleTest(unittest.TestCase):
             Traceback (most recent call last):
               ...
             ZeroDivisionError: multiplication by zero
+            """)
+
+    def testError_printThenException(self):
+        self.calls_interpret(True,
+            """
+            >>> print('hello'); 1 / 0
+            hello
+            Traceback (most recent call last):
+              ...
+            ZeroDivisionError: division by zero
             """)
 
     def testError_onlyExceptionName(self):

--- a/tests/sources/common/pyconsole_test.py
+++ b/tests/sources/common/pyconsole_test.py
@@ -30,7 +30,19 @@ class PythonConsoleTest(unittest.TestCase):
         self.calls_interpret(True,
             """
             >>> 1 / 0
-            ZeroDivisionError
+            Traceback (most recent call last):
+              ...
+            ZeroDivisionError: division by zero
+            """)
+
+    def testPass_expectExceptionAlternateFormat(self):
+        self.calls_interpret(True,
+            """
+            >>> 1 / 0
+            Traceback (innermost last):
+              this line is indented and is ignored
+            # this line starts with a non-alphanumeric character and is ignored
+            ZeroDivisionError: division by zero
             """)
 
     def testPass_multilineSinglePrompt(self):
@@ -58,6 +70,15 @@ class PythonConsoleTest(unittest.TestCase):
             ...     return x * x
             >>> square(4)
             16
+            """)
+
+    def testPass_indentedPrompts(self):
+        self.calls_interpret(True,
+            """
+            >>> print('  >>>')
+              >>>
+            >>> print('  ...')
+              ...
             """)
 
     def testPass_setup(self):
@@ -102,14 +123,38 @@ class PythonConsoleTest(unittest.TestCase):
         self.calls_interpret(False,
             """
             >>> 1 + 2
-            ZeroDivisionError
+            Traceback (most recent call last):
+              ...
+            ZeroDivisionError: division by zero
             """)
 
     def testError_wrongException(self):
         self.calls_interpret(False,
             """
             >>> 1 / 0
-            TypeError
+            Traceback (most recent call last):
+              ...
+            TypeError: division by zero
+            """)
+
+    def testError_wrongExceptionDetail(self):
+        self.calls_interpret(False,
+            """
+            >>> 1 / 0
+            Traceback (most recent call last):
+              ...
+            ZeroDivisionError: multiplication by zero
+            """)
+
+    def testError_notException(self):
+        self.calls_interpret(False,
+            """
+            >>> print('Traceback (most recent call last):')
+            >>> print('  ...')
+            >>> print('ZeroDivisionError: division by zero')
+            Traceback (most recent call last):
+              ...
+            ZeroDivisionError: division by zero
             """)
 
     def testError_runtimeError(self):
@@ -159,9 +204,7 @@ class PythonConsoleTest(unittest.TestCase):
             teardown="""
             >>> 1 / 0
             """)
-            
-    
-        
+
     def testPass_locked(self):
         key = "testKey"
         hashedAnswer = locking.lock(key, "4")
@@ -169,7 +212,7 @@ class PythonConsoleTest(unittest.TestCase):
         >>> 2 + 2
         %s
         """ % hashedAnswer, skip_locked_cases=False, hash_key=key)
-        
+
     def testError_locked(self):
         key = "testKey"
         hashedAnswer = locking.lock(key, "5")
@@ -177,7 +220,7 @@ class PythonConsoleTest(unittest.TestCase):
         >>> 2 + 2
         %s
         """ % hashedAnswer, skip_locked_cases=False, hash_key=key)
-        
+
     def testError_skipLocked(self):
         key = "testKey"
         hashedAnswer = locking.lock(key, "4")

--- a/tests/sources/common/pyconsole_test.py
+++ b/tests/sources/common/pyconsole_test.py
@@ -59,6 +59,13 @@ class PythonConsoleTest(unittest.TestCase):
             ZeroDivisionError: division by zero
             """)
 
+    def testPass_expectLegacyException(self):
+        self.calls_interpret(True,
+            """
+            >>> 1 / 0
+            ZeroDivisionError
+            """)
+
     def testPass_printThenException(self):
         self.calls_interpret(True,
             """
@@ -163,6 +170,13 @@ class PythonConsoleTest(unittest.TestCase):
             ZeroDivisionError: division by zero
             """)
 
+    def testError_expectedLegacyException(self):
+        self.calls_interpret(False,
+            """
+            >>> 1 + 2
+            ZeroDivisionError
+            """)
+
     def testError_wrongException(self):
         self.calls_interpret(False,
             """
@@ -170,6 +184,13 @@ class PythonConsoleTest(unittest.TestCase):
             Traceback (most recent call last):
               ...
             TypeError: division by zero
+            """)
+
+    def testError_wrongLegacyException(self):
+        self.calls_interpret(False,
+            """
+            >>> 1 / 0
+            TypeError
             """)
 
     def testError_wrongExceptionDetail(self):
@@ -189,13 +210,6 @@ class PythonConsoleTest(unittest.TestCase):
             Traceback (most recent call last):
               ...
             ZeroDivisionError: division by zero
-            """)
-
-    def testError_onlyExceptionName(self):
-        self.calls_interpret(False,
-            """
-            >>> 1 / 0
-            ZeroDivisionError
             """)
 
     def testError_notException(self):

--- a/tests/sources/common/pyconsole_test.py
+++ b/tests/sources/common/pyconsole_test.py
@@ -154,6 +154,14 @@ class PythonConsoleTest(unittest.TestCase):
             """)
         self.assertEqual(1, client.foo)
 
+    def testPass_explanation(self):
+        self.calls_interpret(True,
+            """
+            >>> 3 + 4
+            7
+            # explanation: count on your fingers
+            """)
+
     def testError_notEqualError(self):
         self.calls_interpret(False,
             """

--- a/tests/sources/common/pyconsole_test.py
+++ b/tests/sources/common/pyconsole_test.py
@@ -66,6 +66,17 @@ class PythonConsoleTest(unittest.TestCase):
             ZeroDivisionError: division by zero
             """)
 
+    def testPass_multilineExceptionDetail(self):
+        self.calls_interpret(True,
+            """
+            >>> raise ValueError('1\\n  2\\n3')
+            Traceback (most recent call last):
+              ...
+            ValueError: 1
+              2
+            3
+            """)
+
     def testPass_expectExceptionAlternateFormat(self):
         self.calls_interpret(True,
             """
@@ -169,7 +180,7 @@ class PythonConsoleTest(unittest.TestCase):
             """)
 
     def testError_printThenException(self):
-        self.calls_interpret(True,
+        self.calls_interpret(False,
             """
             >>> print('hello'); 1 / 0
             hello
@@ -188,9 +199,7 @@ class PythonConsoleTest(unittest.TestCase):
     def testError_notException(self):
         self.calls_interpret(False,
             """
-            >>> print('Traceback (most recent call last):')
-            >>> print('  ...')
-            >>> print('ZeroDivisionError: division by zero')
+            >>> print('Traceback (most recent call last):\\n  ...\\nZeroDivisionError: division by zero')
             Traceback (most recent call last):
               ...
             ZeroDivisionError: division by zero
@@ -250,6 +259,7 @@ class PythonConsoleTest(unittest.TestCase):
         self.calls_interpret(True, """
         >>> 2 + 2
         %s
+        # locked
         """ % hashedAnswer, skip_locked_cases=False, hash_key=key)
 
     def testError_locked(self):
@@ -258,6 +268,7 @@ class PythonConsoleTest(unittest.TestCase):
         self.calls_interpret(False, """
         >>> 2 + 2
         %s
+        # locked
         """ % hashedAnswer, skip_locked_cases=False, hash_key=key)
 
     def testError_skipLocked(self):
@@ -266,4 +277,5 @@ class PythonConsoleTest(unittest.TestCase):
         self.calls_interpret(False, """
         >>> 2 + 2
         %s
+        # locked
         """ % hashedAnswer)

--- a/tests/sources/common/pyconsole_test.py
+++ b/tests/sources/common/pyconsole_test.py
@@ -151,6 +151,13 @@ class PythonConsoleTest(unittest.TestCase):
             ZeroDivisionError: multiplication by zero
             """)
 
+    def testError_onlyExceptionName(self):
+        self.calls_interpret(False,
+            """
+            >>> 1 / 0
+            ZeroDivisionError
+            """)
+
     def testError_notException(self):
         self.calls_interpret(False,
             """

--- a/tests/sources/common/pyconsole_test.py
+++ b/tests/sources/common/pyconsole_test.py
@@ -6,25 +6,27 @@ import sys
 import unittest
 
 class PythonConsoleTest(unittest.TestCase):
+    def setUp(self):
+        # nosetests captures sys.stdout, but so do we
+        self.stdout = sys.stdout
+        sys.stdout = output._logger = output._OutputLogger(stdout=self.stdout)
+
+    def tearDown(self):
+        sys.stdout = self.stdout
+
     def createConsole(self, verbose=True, interactive=False, timeout=None):
         return pyconsole.PythonConsole(
                 verbose, interactive, timeout)
 
     def calls_interpret(self, success, code, setup='', teardown='', skip_locked_cases=True, hash_key=None):
-        # nosetests captures sys.stdout, but so do we
-        stdout = sys.stdout
-        try:
-            sys.stdout = output._logger = output._OutputLogger(stdout=stdout)
-            self.console = self.createConsole()
-            self.console.skip_locked_cases = skip_locked_cases
-            self.console.hash_key = hash_key
-            lines = interpreter.CodeCase.split_code(code, self.console.PS1,
-                                                    self.console.PS2)
-            self.console.load(lines, setup, teardown)
-            result = self.console.interpret()
-            self.assertEqual(success, result)
-        finally:
-            sys.stdout = stdout
+        self.console = self.createConsole()
+        self.console.skip_locked_cases = skip_locked_cases
+        self.console.hash_key = hash_key
+        lines = interpreter.CodeCase.split_code(code, self.console.PS1,
+                                                self.console.PS2)
+        self.console.load(lines, setup, teardown)
+        result = self.console.interpret()
+        self.assertEqual(success, result)
 
     def testPass_equals(self):
         self.calls_interpret(True,

--- a/tests/utils/output_test.py
+++ b/tests/utils/output_test.py
@@ -2,22 +2,17 @@ from client.utils import output
 import sys
 import unittest
 
-LOGGER = sys.stdout
-assert isinstance(LOGGER, output._OutputLogger)
-sys.stdout = sys.__stdout__
-
 class OutputLoggerTest(unittest.TestCase):
     MESSAGE1 = 'message 1'
     MESSAGE2 = 'message 2'
 
     def setUp(self):
-        sys.stdout = LOGGER
-        output.on()
+        # nosetests captures sys.stdout, but so do we
+        self.stdout = sys.stdout
+        sys.stdout = output._logger = output._OutputLogger(stdout=self.stdout)
 
     def tearDown(self):
-        output.on()
-        output.remove_all_logs()
-        sys.stdout = sys.__stdout__
+        sys.stdout = self.stdout
 
     def testRegisterLog_oneLog_outputOn(self):
         output.on()


### PR DESCRIPTION
This changes how exceptions in doctests and OK tests are handled to match the [doctest module's exception handling](https://docs.python.org/3/library/doctest.html#what-about-exceptions). In addition to
```
>>> raise ValueError('hello')
ValueError
```

you can also write
```
>>> raise ValueError('hello')
Traceback (most recent call last):
  ...
ValueError: hello
```