### PR TITLE
Find doctests recursively so class methods are loaded

### DIFF
--- a/client/sources/doctest/__init__.py
+++ b/client/sources/doctest/__init__.py
@@ -46,11 +46,17 @@ def load(file, name, assign):
 
 
 def _load_tests(file, module, assign):
+    """Recursively find doctests from all objects in MODULE."""
     tests = {}
-    for name in dir(module):
-        to_test = getattr(module, name)
-        if callable(to_test) and to_test.__module__ == module.__name__:
-            tests[name] = _load_test(file, module, name, assign)
+    def _load_tests_from_obj(obj, attribute_path):
+        for attr in dir(obj):
+            to_test = getattr(obj, attr)
+            if callable(to_test) and getattr(to_test, '__module__', None) == module.__name__:
+                path = attribute_path + [attr]
+                name = '.'.join(path)
+                tests[name] = _load_test(file, module, name, assign)
+                _load_tests_from_obj(to_test, path)
+    _load_tests_from_obj(module, [])
     return tests
 
 def _load_test(file, module, name, assign):


### PR DESCRIPTION
Specifying doctests as
```
"tests": {
    "hw04.py": "doctest"
}
```
is supposed to load all doctests from a file, but it would miss doctests on class methods. Using the power of recursion we can now see everything.

Tested with http://cs61a.org/hw/hw04/

Before:
```
> python3 ok --tests --no-update
=====================================================================
Assignment: Homework 4
OK, version v1.10.1
=====================================================================

Available tests:
    balanced
    branches
    centered_interval
    end
    examples
    interval
    is_leaf
    is_tree
    is_weight
    label
    length
    make_anonymous_factorial
    make_counter
    make_fib
    mobile
    move_stack
    print_move
    side
    sides
    size
    total_weight
    tree
    weight
    with_totals
```

After:
```
> python3 ok --tests --no-update
=====================================================================
Assignment: Homework 4
OK, version v1.10.1
=====================================================================

Available tests:
    balanced
    branches
    centered_interval
    centered_interval.__init__
    centered_interval.__repr__
    centered_interval.__str__
    centered_interval.center
    centered_interval.make_interval
    centered_interval.tolerance
    end
    examples
    interval
    interval.make_interval
    is_leaf
    is_tree
    is_weight
    label
    length
    make_anonymous_factorial
    make_counter
    make_fib
    mobile
    move_stack
    print_move
    side
    sides
    size
    total_weight
    tree
    weight
    with_totals
```