### PR TITLE
Use Auth Header (Bearer Token)

### DIFF
--- a/client/protocols/backup.py
+++ b/client/protocols/backup.py
@@ -232,14 +232,16 @@ class BackupProtocol(models.Protocol):
             address = self.REVISION_ENDPOINT.format(server=self.assignment.server_url)
         else:
             address = self.BACKUP_ENDPOINT.format(server=self.assignment.server_url)
+
         address_params = {
-            'access_token': access_token,
             'client_name': 'ok-client',
             'client_version': client.__version__,
         }
 
+        headers = {'Authorization': 'Bearer {}'.format(access_token)}
+
         log.info('Sending messages to %s', address)
-        response = requests.post(address,
+        response = requests.post(address, headers=headers,
             params=address_params, json=data, timeout=timeout)
         response.raise_for_status()
         return response.json()

--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -322,7 +322,7 @@ def notebook_get_code(assignment):
 def get_info(assignment, access_token):
     response = requests.get(
         assignment.server_url + INFO_ENDPOINT,
-        params={'access_token': access_token},
+        headers={'Authentication': 'Bearer {}'.format(access_token)},
         timeout=5)
     response.raise_for_status()
     return response.json()['data']

--- a/demo/ok_test/config.ok
+++ b/demo/ok_test/config.ok
@@ -1,6 +1,6 @@
 {
     "name": "Homework 1",
-    "endpoint": "https://okpy.org/path/to/endpoint",
+    "endpoint": "ok/test/su16/ex",
     "src": [
         "hw1.py"
     ],


### PR DESCRIPTION
Resolves #286 

The only thing that now uses access tokens as query parameters is collaborate - but the collab server isn't equipped to accept auth tokens through headers. 