### PR TITLE
Script to release ok-client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.github-token
+
 bin
 env
 include

--- a/README.md
+++ b/README.md
@@ -50,24 +50,21 @@ To run all tests, use the following command:
 
     nosetests tests
 
-## Deployment
+## Releasing an ok-client version
 
-To deploy a new version of ok-client, do the following:
+First make sure that
 
-1. Change the version number in `client/__init__.py`.
-2. Make sure your virtualenv is activated. Also make sure that your `~/.pypirc`
-   contains okpy's Pypi credentials.
-3. From the base of the repo, make sure your virtualenv is activated and run
+* Your virtualenv is activated and you are on the master branch.
+* Your `~/.pypirc` contains okpy's PyPI credentials.
+* A file `.github-token` contains a [GitHub access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/).
 
-        python setup.py sdist upload
+To deploy a new version of ok-client, change to the `master` branch and run
 
-4. Make sure to deploy a development version locally:
+    ./release.py vX.X.X
 
-        python setup.py develop
+where `vX.X.X` is the new version. This will:
 
-5. Create an `ok` binary:
-
-        ok-publish
-
-6. Draft a new release on Github with the newly created `ok` binary.
-7. Update the version and Github link on [okpy.org](https://okpy.org/admin/versions/ok-client)
+* Change the version number
+* Create a GitHub release
+* Change the ok-client version on https://okpy.org/admin/versions/ok-client
+* Upload the release to PyPI

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ First make sure that
 
 * Your virtualenv is activated and you are on the master branch.
 * Your `~/.pypirc` contains okpy's PyPI credentials.
-* A file `.github-token` contains a [GitHub access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/).
+* A file `.github-token` contains a
+  [GitHub access token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/)
+  with the "repo" scope.
 
 To deploy a new version of ok-client, change to the `master` branch and run
 

--- a/release.py
+++ b/release.py
@@ -70,7 +70,7 @@ if __name__ == '__main__':
     new_release = sys.argv[1]
 
     # change to directory that script is in; should be root of project
-    os.chdir(os.path.dirname(__file__))
+    os.chdir(os.path.dirname(os.path.realpath(__file__)))
 
     # read GitHub token
     try:

--- a/release.py
+++ b/release.py
@@ -97,12 +97,16 @@ if __name__ == '__main__':
     print('Latest version: {} ({})'.format(latest_release, latest_release_commit[:7]))
     print('New version: {}'.format(new_release))
 
-    # check that release numbers are increasing
+    # check that release numbers are sane
     try:
-        if StrictVersion(latest_release[1:]) >= StrictVersion(new_release[1:]):
-            abort('Version numbers must be increasing')
+        latest_version = StrictVersion(latest_release[1:])
+        new_version = StrictVersion(new_release[1:])
     except ValueError as e:
         abort(str(e))
+    if latest_version >= new_version:
+        abort('Version numbers must be increasing')
+    elif new_version.version[0] > latest_version.version[0] + 1:
+        abort('Major version number cannot increase by more than one')
 
     # edit changelog message
     log = shell('git log --pretty=format:"- %s" {}..HEAD'.format(latest_release),

--- a/release.py
+++ b/release.py
@@ -136,6 +136,7 @@ if __name__ == '__main__':
         shell('git push')
 
     print('Uploading release to GitHub...')
+    shell('python setup.py develop')
     shell('ok-publish')
     github_release = post_request(
         'https://api.github.com/repos/{}/releases'.format(GITHUB_REPO),

--- a/release.py
+++ b/release.py
@@ -54,9 +54,10 @@ def edit(text):
         os.unlink(name)
     return t
 
-def post_request(*args, **kwargs):
+def post_request(url, *args, **kwargs):
     try:
-        r = requests.post(*args, **kwargs)
+        print('POST', url)
+        r = requests.post(url, *args, **kwargs)
         r.raise_for_status()
     except Exception as e:
         abort(str(e))

--- a/release.py
+++ b/release.py
@@ -16,7 +16,7 @@ OK_SERVER_URL = 'http://localhost:5000'
 
 def abort(message=None):
     if message:
-        print(message, file=sys.stderr)
+        print('ERROR:', message, file=sys.stderr)
     sys.exit(1)
 
 def shell(command, capture_output=False):

--- a/release.py
+++ b/release.py
@@ -185,7 +185,6 @@ if __name__ == '__main__':
     )
 
     print('Uploading release to PyPI...')
-    shell('python setup.py develop')
     # shell('python setup.py sdist upload')
 
     print('Done. Remember to update the requirements.txt file for any repos')

--- a/release.py
+++ b/release.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
         abort("Version must start with 'v'")
     if shell('git rev-parse --abbrev-ref HEAD') != 'master':
         abort('You must be on master to release a new version')
-    shell('git pull', capture_output=False, echo=True)
+    shell('git pull --ff-only', capture_output=False, echo=True)
 
     # find latest release
     latest_release = shell('git describe --tags --abbrev=0')

--- a/release.py
+++ b/release.py
@@ -169,7 +169,7 @@ if __name__ == '__main__':
     args = assignment._MockNamespace()
     class FakeAssignment:
         def __init__(self):
-            self.args = assignment._MockNamespace()
+            self.cmd_args = assignment._MockNamespace()
             self.server_url = OK_SERVER_URL
             self.endpoint = ''
     access_token = auth.authenticate(FakeAssignment())

--- a/release.py
+++ b/release.py
@@ -28,9 +28,9 @@ def shell(command, capture_output=False):
     try:
         output = subprocess.run(command, **kwargs)
     except subprocess.CalledProcessError as e:
-        print(str(e))
+        print(str(e), file=sys.stderr)
         if capture_output:
-            print(e.stderr.decode('utf-8'))
+            print(e.stderr.decode('utf-8'), file=sys.stderr)
         abort()
     if capture_output:
         return output.stdout.decode('utf-8').strip()

--- a/release.py
+++ b/release.py
@@ -62,14 +62,6 @@ def post_request(*args, **kwargs):
         abort(str(e))
     return r.json()
 
-def github(endpoint, domain='api.github.com', token='', **kwargs):
-    path = os.path.join('/repos/Cal-CS-61A-Staff/ok-client', endpoint)
-    headers = kwargs.pop('headers', {})
-    if token:
-        headers['authorization'] = 'token {}'.format(token)
-    return post_request('https://{}/{}'.format(domain, endpoint),
-        headers=headers, **kwargs)
-
 if __name__ == '__main__':
     if len(sys.argv) < 2:
         print('Usage: {} NEW_VERSION'.format(sys.argv[0]), file=sys.stderr)
@@ -145,7 +137,9 @@ if __name__ == '__main__':
     shell('ok-publish')
     github_release = post_request(
         'https://api.github.com/repos/{}/releases'.format(GITHUB_REPO),
-        token=github_token,
+        headers={
+            'Authorization': 'token ' + github_token,
+        },
         json={
             'tag_name': new_release,
             'target_commitish': 'master',
@@ -162,9 +156,9 @@ if __name__ == '__main__':
             params={
                 'name': 'ok'
             },
-            token=github_token,
             headers={
-                'content-type': 'application/octet-stream'
+                'Authorization': 'token ' + github_token,
+                'Content-Type': 'application/octet-stream',
             },
             data=f,
         )
@@ -179,7 +173,9 @@ if __name__ == '__main__':
             self.endpoint = ''
     access_token = auth.authenticate(FakeAssignment())
     post_request('https://{}/api/v3/versions/ok-client'.format(OK_SERVER_DOMAIN),
-        token=access_token,
+        headers={
+            'Authorization': 'Bearer ' + access_token,
+        },
         json={
             'current_version': new_release,
             'download_link': github_asset['browser_download_url'],

--- a/release.py
+++ b/release.py
@@ -11,8 +11,8 @@ from client.api import assignment
 from client.utils import auth
 
 GITHUB_TOKEN_FILE = '.github-token'
-GITHUB_REPO = 'Cal-CS-61A-Staff/ok-client'
-OK_SERVER_DOMAIN = 'okpy.org'
+GITHUB_REPO = 'okpy/ok-client'
+OK_SERVER_DOMAIN = 'localhost:5000'
 
 def abort(message=None):
     if message:
@@ -188,7 +188,7 @@ if __name__ == '__main__':
 
     print('Uploading release to PyPI...')
     shell('python setup.py develop', echo=True)
-    shell('python setup.py sdist upload', echo=True)
+    # shell('python setup.py sdist upload', echo=True)
 
     print('Done. Remember to update the requirements.txt file for any repos')
     print('that depend on okpy.')

--- a/release.py
+++ b/release.py
@@ -174,7 +174,7 @@ if __name__ == '__main__':
             self.server_url = OK_SERVER_URL
             self.endpoint = ''
     access_token = auth.authenticate(FakeAssignment())
-    post_request('{}/api/v3/versions/ok-client'.format(OK_SERVER_URL),
+    post_request('{}/api/v3/version/ok-client'.format(OK_SERVER_URL),
         headers={
             'Authorization': 'Bearer ' + access_token,
         },

--- a/release.py
+++ b/release.py
@@ -184,7 +184,7 @@ if __name__ == '__main__':
     )
 
     print('Uploading release to PyPI...')
-    shell('python setup.py sdist upload')
+    shell('python setup.py sdist bdist_wheel upload')
 
     print()
     print('Released okpy=={}'.format(new_release))

--- a/release.py
+++ b/release.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+from distutils.version import StrictVersion
+import os
+import re
+import requests
+import subprocess
+import sys
+import tempfile
+
+from client.api import assignment
+from client.utils import auth
+
+GITHUB_TOKEN_FILE = '.github-token'
+GITHUB_REPO = 'Cal-CS-61A-Staff/ok-client'
+
+def abort(message=None):
+    if message:
+        print(message, file=sys.stderr)
+    sys.exit(1)
+
+def shell(command, capture_output=True, echo=False):
+    if echo:
+        print('>', command)
+    kwargs = dict(shell=True, check=True)
+    if capture_output:
+        kwargs.update(stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+    try:
+        output = subprocess.run(command, **kwargs)
+    except subprocess.CalledProcessError as e:
+        print(str(e))
+        if capture_output:
+            print(e.stderr.decode('utf-8'))
+        abort()
+    if capture_output:
+        return output.stdout.decode('utf-8').strip()
+
+def edit(text):
+    # from Mercurial sources:
+    # https://selenic.com/repo/hg-stable/file/2770d03ae49f/mercurial/ui.py#l318
+    (fd, name) = tempfile.mkstemp(
+        prefix='ok-client-release-', suffix='.txt', text=True)
+    try:
+        f = os.fdopen(fd, 'w')
+        f.write(text)
+        f.close()
+
+        editor = os.environ.get('EDITOR', 'vi')
+        shell('{} \"{}\"'.format(editor, name), capture_output=False)
+        f = open(name)
+        t = f.read()
+        f.close()
+    finally:
+        os.unlink(name)
+    return t
+
+def post_request(*args, **kwargs):
+    try:
+        r = requests.post(*args, **kwargs)
+        r.raise_for_status()
+    except Exception as e:
+        abort(str(e))
+    return r.json()
+
+def github(endpoint, domain='api.github.com', token='', **kwargs):
+    path = os.path.join('/repos/Cal-CS-61A-Staff/ok-client', endpoint)
+    headers = kwargs.pop('headers', {})
+    if token:
+        headers['authorization'] = 'token {}'.format(token)
+    return post_request('https://{}/{}'.format(domain, endpoint),
+        headers=headers, **kwargs)
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print('Usage: {} NEW_VERSION'.format(sys.argv[0]), file=sys.stderr)
+        abort()
+    new_release = sys.argv[1]
+
+    # change to directory that script is in; should be root of project
+    os.chdir(os.path.dirname(__file__))
+
+    # read GitHub token
+    try:
+        with open(GITHUB_TOKEN_FILE, 'r') as f:
+            github_token = f.read().strip()
+    except (OSError, IOError) as e:
+        print('No GitHub access token found.', file=sys.stderr)
+        print('Generate an access token with the "repo" scope as per', file=sys.stderr)
+        print('https://help.github.com/articles/creating-an-access-token-for-command-line-use/', file=sys.stderr)
+        print('and paste the token into a file named "{}".'.format(GITHUB_TOKEN_FILE), file=sys.stderr)
+        abort()
+
+    if new_release[:1] != 'v':
+        abort("Version must start with 'v'")
+    if shell('git rev-parse --abbrev-ref HEAD') != 'master':
+        abort('You must be on master to release a new version')
+    shell('git pull', capture_output=False, echo=True)
+
+    # find latest release
+    latest_release = shell('git describe --tags --abbrev=0')
+    latest_release_commit = shell('git rev-list -n 1 {}'.format(latest_release))
+
+    print('Latest version: {} ({})'.format(latest_release, latest_release_commit[:7]))
+    print('New version: {}'.format(new_release))
+
+    # check that release numbers are increasing
+    try:
+        if StrictVersion(latest_release[1:]) >= StrictVersion(new_release[1:]):
+            abort('Version numbers must be increasing')
+    except ValueError as e:
+        abort(str(e))
+
+    # edit changelog message
+    log = shell('git log --pretty=format:"- %s" {}..HEAD'.format(latest_release))
+    changelog = edit('\n'.join([
+        'Changelog',
+        log,
+        '',
+        '# Please enter a changelog since the latest release. Lines starting',
+        "# with '#' will be ignored, and an empty message aborts the release.",
+    ]))
+    log_lines = [line for line in changelog.splitlines() if line[:1] != '#']
+    changelog = '\n'.join(log_lines).strip()
+    if not changelog:
+        abort('Empty changelog, aborting')
+
+    # edit client/__init__.py and commit
+    init_file = 'client/__init__.py'
+    with open(init_file, 'r', encoding='utf-8') as f:
+        old_init = f.read()
+    new_init = re.sub(
+        r"^__version__ = '([a-zA-Z0-9.]+)'",
+        "__version__ = '{}'".format(new_release),
+        old_init)
+    if old_init != new_init:
+        print('Editing version string in {}'.format(init_file))
+        with open(init_file, 'w', encoding='utf-8') as f:
+            init = f.write(new_init)
+        shell('git add {}'.format(init_file), capture_output=False, echo=True)
+        shell('git commit -m "Bump version to {}"'.format(new_release),
+            capture_output=False, echo=True)
+        shell('git push', capture_output=False, echo=True)
+
+    print('Uploading release to GitHub...')
+    shell('ok-publish')
+    github_release = post_request(
+        'https://api.github.com/repos/{}/releases'.format(GITHUB_REPO),
+        token=github_token,
+        json={
+            'tag_name': new_release,
+            'target_commitish': 'master',
+            'name': new_release,
+            'body': changelog,
+            'draft': False,
+            'prerelease': False
+        },
+    )
+    with open('ok', 'rb') as f:
+        github_asset = post_request(
+            'https://uploads.github.com/repos/{}/releases/{}/assets'.format(
+                GITHUB_REPO, github_release['id']),
+            params={
+                'name': 'ok'
+            },
+            token=github_token,
+            headers={
+                'content-type': 'application/octet-stream'
+            },
+            data=f,
+        )
+
+    print('Updating version on okpy.org...')
+    access_token = auth.authenticate(args, server_url)
+    post_request('https://okpy.org/api/v3/versions/ok-client',
+        token=access_token,
+        json={
+            'current_version': new_release,
+            'download_link': github_asset['browser_download_url'],
+        },
+    )
+
+    print('Uploading release to PyPI...')
+    shell('python setup.py develop', echo=True)
+    shell('python setup.py sdist upload', echo=True)
+
+    print('Done. Remember to update the requirements.txt file for any repos')
+    print('that depend on okpy.')

--- a/release.py
+++ b/release.py
@@ -187,5 +187,6 @@ if __name__ == '__main__':
     print('Uploading release to PyPI...')
     # shell('python setup.py sdist upload')
 
-    print('Done. Remember to update the requirements.txt file for any repos')
-    print('that depend on okpy.')
+    print()
+    print('Released okpy=={}'.format(new_release))
+    print('Remember to update the requirements.txt file for any repos that depend on okpy.')

--- a/release.py
+++ b/release.py
@@ -97,6 +97,9 @@ if __name__ == '__main__':
     print('Latest version: {} ({})'.format(latest_release, latest_release_commit[:7]))
     print('New version: {}'.format(new_release))
 
+    # run tests
+    shell('nosetests tests')
+
     # check that release numbers are sane
     try:
         latest_version = StrictVersion(latest_release[1:])

--- a/release.py
+++ b/release.py
@@ -12,7 +12,7 @@ from client.utils import auth
 
 GITHUB_TOKEN_FILE = '.github-token'
 GITHUB_REPO = 'okpy/ok-client'
-OK_SERVER_DOMAIN = 'localhost:5000'
+OK_SERVER_URL = 'http://localhost:5000'
 
 def abort(message=None):
     if message:
@@ -164,16 +164,16 @@ if __name__ == '__main__':
             data=f,
         )
 
-    print('Updating version on {}...'.format(OK_SERVER_DOMAIN))
+    print('Updating version on {}...'.format(OK_SERVER_URL))
     # Create a fake assignment to log in. I'm not happy about this
     args = assignment._MockNamespace()
     class FakeAssignment:
         def __init__(self):
             self.args = assignment._MockNamespace()
-            self.args.server = OK_SERVER_DOMAIN
+            self.server_url = OK_SERVER_URL
             self.endpoint = ''
     access_token = auth.authenticate(FakeAssignment())
-    post_request('https://{}/api/v3/versions/ok-client'.format(OK_SERVER_DOMAIN),
+    post_request('{}/api/v3/versions/ok-client'.format(OK_SERVER_URL),
         headers={
             'Authorization': 'Bearer ' + access_token,
         },

--- a/release.py
+++ b/release.py
@@ -167,7 +167,6 @@ if __name__ == '__main__':
 
     print('Updating version on {}...'.format(OK_SERVER_URL))
     # Create a fake assignment to log in. I'm not happy about this
-    args = assignment._MockNamespace()
     class FakeAssignment:
         def __init__(self):
             self.cmd_args = assignment._MockNamespace()

--- a/release.py
+++ b/release.py
@@ -11,8 +11,8 @@ from client.api import assignment
 from client.utils import auth
 
 GITHUB_TOKEN_FILE = '.github-token'
-GITHUB_REPO = 'okpy/ok-client'
-OK_SERVER_URL = 'http://localhost:5000'
+GITHUB_REPO = 'Cal-CS-61A-Staff/ok-client'
+OK_SERVER_DOMAIN = 'https://okpy.org'
 
 def abort(message=None):
     if message:
@@ -185,7 +185,7 @@ if __name__ == '__main__':
     )
 
     print('Uploading release to PyPI...')
-    # shell('python setup.py sdist upload')
+    shell('python setup.py sdist upload')
 
     print()
     print('Released okpy=={}'.format(new_release))

--- a/release.py
+++ b/release.py
@@ -164,7 +164,7 @@ if __name__ == '__main__':
             data=f,
         )
 
-    print('Updating version on okpy.org...')
+    print('Updating version on {}...'.format(OK_SERVER_DOMAIN))
     # Create a fake assignment to log in. I'm not happy about this
     args = assignment._MockNamespace()
     class FakeAssignment:

--- a/release.py
+++ b/release.py
@@ -12,6 +12,7 @@ from client.utils import auth
 
 GITHUB_TOKEN_FILE = '.github-token'
 GITHUB_REPO = 'Cal-CS-61A-Staff/ok-client'
+OK_SERVER_DOMAIN = 'okpy.org'
 
 def abort(message=None):
     if message:
@@ -169,8 +170,15 @@ if __name__ == '__main__':
         )
 
     print('Updating version on okpy.org...')
-    access_token = auth.authenticate(args, server_url)
-    post_request('https://okpy.org/api/v3/versions/ok-client',
+    # Create a fake assignment to log in. I'm not happy about this
+    args = assignment._MockNamespace()
+    class FakeAssignment:
+        def __init__(self):
+            self.args = assignment._MockNamespace()
+            self.args.server = OK_SERVER_DOMAIN
+            self.endpoint = ''
+    access_token = auth.authenticate(FakeAssignment())
+    post_request('https://{}/api/v3/versions/ok-client'.format(OK_SERVER_DOMAIN),
         token=access_token,
         json={
             'current_version': new_release,


### PR DESCRIPTION
Resolves #264, #276.

Test plan:
  * Clone into a new github repo for testing
  * Comment out the `python setup.py sdist upload`
  * Edit `GITHUB_REPO` to point to the testing repo
  * Edit `OK_SERVER_URL` to point to `localhost:5000`
  * Try to "release" the fake client. Should see
    * Version bump pushed to github
    * GitHub release with correct binary
    * Updated client version on localhost:5000