### PR TITLE
Use correct header for OK auth

### DIFF
--- a/client/__init__.py
+++ b/client/__init__.py
@@ -1,4 +1,4 @@
-__version__ = 'v1.10.3'
+__version__ = 'v1.10.4'
 
 FILE_NAME = 'ok'
 

--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -322,7 +322,7 @@ def notebook_get_code(assignment):
 def get_info(assignment, access_token):
     response = requests.get(
         assignment.server_url + INFO_ENDPOINT,
-        headers={'Authentication': 'Bearer {}'.format(access_token)},
+        headers={'Authorization': 'Bearer {}'.format(access_token)},
         timeout=5)
     response.raise_for_status()
     return response.json()['data']


### PR DESCRIPTION
All requests to get_info (when we tried to get emails) were failing. 

Discovered when `--collab` stopped working (because it didn't get the emails) 