### PR TITLE
Auth without assignment config

### DIFF
--- a/client/api/assignment.py
+++ b/client/api/assignment.py
@@ -272,3 +272,18 @@ class _MockNamespace(object):
 
     def __getattr__(self, attr):
         return getattr(self.args, attr)
+
+class AuthAssignment(object):
+    """A mock Assignment object that is meant to be a substitute for an 
+    Assignment for use with authentication-related work that doesn't need
+    a full assignment.
+
+    (see Design Note above in _MockNamespace)
+    """
+    def __init__(self):
+        self.cmd_args = _MockNamespace()
+        self.server_url = 'https://okpy.org'
+        self.endpoint = ''
+
+    def dump_tests(self):
+        pass

--- a/client/cli/ok.py
+++ b/client/cli/ok.py
@@ -175,9 +175,8 @@ def main():
 
     assign = None
     try:
-        # Instantiating assignment
-        assign = assignment.load_assignment(args.config, args)
-
+        # Instantiating an AuthAssignment for Auth-related requests
+        assign = assignment.AuthAssignment()
         if args.authenticate:
             # Authenticate and check for success
             if not auth.authenticate(assign, force=True):
@@ -188,6 +187,8 @@ def main():
             print("Token: {}".format(access_token))
             exit(not access_token)  # exit with error if no access_token
 
+        # Instantiating assignment
+        assign = assignment.load_assignment(args.config, args)
         if args.tests:
             print('Available tests:')
             for name in assign.test_map:


### PR DESCRIPTION
Resolves #290, allowing you to use `--get-token` without an assignment config.

For API usage:
```
from client.api import assignment
from client.utils import auth

assign = assignment.AuthAssignment()
access_token = auth.authenticate(assign)
```
