### PR TITLE
Add per-question rate limiting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ tmp
 *.pydevproject
 *.kpf
 .coverage
+.ok_storage
 
 # pip-related files
 *.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
@@ -12,7 +11,6 @@ install:
 cache:
   directories:
   - "$HOME/.cache/pip"
-  - lib/python3.3/site-packages
   - lib/python3.4/site-packages
   - lib/python3.5/site-packages
   - lib/python3.6/site-packages

--- a/client/api/assignment.py
+++ b/client/api/assignment.py
@@ -121,12 +121,14 @@ class Assignment(core.Serializable):
     # backup        -> all other protocols
     # collaborate   -> file_contents, analytics
     # file_contents -> none
-    # grading       -> none
+    # grading       -> rate_limit
     # hinting       -> file_contents, analytics
     # lock          -> none
+    # rate_limit    -> none
     # scoring       -> none
     # unlock        -> none
     _PROTOCOLS = [
+        "rate_limit",
         "file_contents",
         "grading",
         "analytics",

--- a/client/protocols/rate_limit.py
+++ b/client/protocols/rate_limit.py
@@ -1,0 +1,81 @@
+from client.protocols.common import models
+from client.exceptions import ProtocolException
+import time
+
+
+BACKOFF_POLICY = (0, 0, 180, 300) # 1-2 no penalty, penalty in seconds after
+
+
+##################
+# Secure Storage #  TODO: refactor persistance to one centralized location
+##################
+
+import shelve # persistance
+import hmac # security
+
+SHELVE_FILE = '.ok_storage'
+SECURITY_KEY = 'uMWm4sviPK3LyPzgWYFn'.encode('utf-8')
+
+def mac(value):
+    mac = hmac.new(SECURITY_KEY)
+    mac.update(repr(value).encode('utf-8'))
+    return mac.hexdigest()
+
+def check(root, key):
+    key = '{}-{}'.format(root, key)
+    with shelve.open(SHELVE_FILE) as db:
+        return key in db
+
+def store(root, key, value):
+    key = '{}-{}'.format(root, key)
+    with shelve.open(SHELVE_FILE) as db:
+        db[key] = {'value': value, 'mac': mac(value)}
+    return value
+
+def get(root, key):
+    key = '{}-{}'.format(root, key)
+    with shelve.open(SHELVE_FILE) as db:
+        data = db[key]
+        if not hmac.compare_digest(data['mac'], mac(data['value'])):
+            raise ProtocolException('{} was tampered.  Reverse changes, or redownload assignment'.format(SHELVE_FILE))
+    return data['value']
+
+
+###########################
+# Rate Limiting Mechanism #
+###########################
+
+class RateLimitProtocol(models.Protocol):
+    """A Protocol that keeps track of rate limiting for specific questions.
+    """
+    def __init__(self, args, assignment, backoff=BACKOFF_POLICY):
+        self.backoff = backoff
+        super().__init__(args, assignment)
+
+    def run(self, messages):
+        if self.args.score or self.args.unlock:
+            return
+        analytics = {}
+        tests = self.assignment.specified_tests
+        for test in tests:
+            last_attempt, attempts = self.check_attempt(test)
+            analytics[test.name] = {
+                'attempts': store(test.name, 'attempts', attempts),
+                'last_attempt': store(test.name, 'last_attempt', last_attempt)}
+
+        messages['rate_limit'] = {}
+
+    def check_attempt(self, test):
+        now = int(time.time())
+        if not check(test.name, 'last_attempt') or not check(test.name, 'attempts'):
+            return now, 1  # First attempt
+        last_attempt = get(test.name, 'last_attempt')
+        attempts = get(test.name, 'attempts')
+        secs_elapsed = now - last_attempt
+        backoff_time = self.backoff[attempts] if attempts < len(self.backoff) else self.backoff[-1]
+        cooldown = backoff_time - secs_elapsed
+        if cooldown > 0:
+            raise ProtocolException('Cooling down... {} s to go! (total attempts: {})'.format(cooldown, attempts))
+        return now, attempts + 1
+
+protocol = RateLimitProtocol

--- a/tests/protocols/rate_limit_test.py
+++ b/tests/protocols/rate_limit_test.py
@@ -1,0 +1,49 @@
+"""Tests the UnlockProtocol."""
+from client.protocols import rate_limit
+from client.sources.common import models
+from client.exceptions import ProtocolException
+import mock
+import time
+import os
+import unittest
+
+class RateLimitProtocolTest(unittest.TestCase):
+    def setUp(self):
+        os.remove('.ok_storage') if os.path.exists('.ok_storage') else None
+        self.cmd_args = mock.Mock()
+        self.cmd_args.score = False
+        self.cmd_args.unlock = False
+        self.cmd_args.restore = False
+        self.assignment = mock.Mock()
+        self.proto = rate_limit.protocol(self.cmd_args, self.assignment, backoff=[0,0,2,4])
+
+    def callRun(self):
+        messages = {}
+        self.proto.run(messages)
+        self.assertIn('rate_limit', messages)
+        return messages['rate_limit']
+
+    def make_attempt(self, test, attempts, succeeds=True):
+        self.assignment.specified_tests = [test]
+        if not succeeds:
+            with self.assertRaises(ProtocolException):
+                self.callRun()
+        else:
+            self.callRun()
+        self.assertTrue(rate_limit.get(test.name, 'attempts') == attempts, 'attempts not correct')
+
+    def testManyAttempts(self):
+        test = mock.Mock(spec=models.Test)
+        test.name = 'test'
+        self.make_attempt(test, 1)
+        self.make_attempt(test, 2, succeeds=True)
+        self.make_attempt(test, 2, succeeds=False)
+        time.sleep(2)
+        self.make_attempt(test, 3, succeeds=True)
+        self.make_attempt(test, 3, succeeds=False)
+        time.sleep(3)
+        self.make_attempt(test, 3, succeeds=False)
+        time.sleep(1)
+        self.make_attempt(test, 4, succeeds=True)
+        time.sleep(4)
+        self.make_attempt(test, 5, succeeds=True)


### PR DESCRIPTION
Added a new protocol `rate_limit` that handles rate-limiting per question (requested by 61A su17 course staff).

Current backoff is None for attempts 1-2, 3min for attempt 3, and 5min for attempts 4+.  (Open to opinions - can easily be changed by modifying `BACKOFF` in the `rate_limit.py` file.)

![snip20170618_35](https://user-images.githubusercontent.com/8680381/27260102-73b93de4-53d8-11e7-89cf-142eb5c9a4a4.png)
![snip20170618_36](https://user-images.githubusercontent.com/8680381/27260104-75374ca6-53d8-11e7-9390-83b3ca9035a3.png)

Notable implementation details:
- uses `hmac` and `shelve` builtin libraries for secure persistence
- should resist tampering with the `.ok_storage` file where rate-limit data is stored
- should also resist redownloading assignment to circumvent rate-limiting