### PR TITLE
mutate Settings when calling `Assignment.set_args`

### DIFF
--- a/client/api/assignment.py
+++ b/client/api/assignment.py
@@ -163,7 +163,7 @@ class Assignment(core.Serializable):
                 timeout=60,
             )
         """
-        self.cmd_args = Settings(**kwargs)
+        self.cmd_args.update(**kwargs)
 
     def authenticate(self, force=False, inline=False):
         if not inline:
@@ -285,8 +285,15 @@ class Settings:
     def __init__(self, **kwargs):
         from client.cli.ok import parse_input
         self.args = parse_input([])
-        for k, v in kwargs.items():
-            setattr(self.args, k, v)
+        self.update(**kwargs)
 
     def __getattr__(self, attr):
         return getattr(self.args, attr)
+
+    def update(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self.args, k, v)
+
+    def __repr__(self):
+        cls = type(self).__name__
+        return "{0}({1})".format(cls, vars(self.args))


### PR DESCRIPTION
Resolves #310 

Changelog:
- add new `Settings.update` method that mutates Settings object with new settings
- call this method in `set_args` instead of `self.cmd_args = Settings(...)` as before

Proper submitting for data8 should work now.
