### PR TITLE
Catch and Handle More Auth Exceptions

### DIFF
--- a/client/exceptions.py
+++ b/client/exceptions.py
@@ -1,8 +1,20 @@
 """Client exceptions."""
 
+import client
 
-class OkException(BaseException):
+import sys
+import logging
+
+log = logging.getLogger(__name__)   # Get top-level logger
+
+class OkException(Exception):
     """Base exception class for OK."""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        log.debug('Exception raised: {}'.format(type(self).__name__))
+        log.debug('python version: {}'.format(sys.version_info))
+        log.debug('okpy version: {}'.format(client.__version__))
+
 
 
 class AuthenticationException(OkException):

--- a/client/exceptions.py
+++ b/client/exceptions.py
@@ -9,6 +9,13 @@ class AuthenticationException(OkException):
     """Exceptions related to authentication."""
 
 
+class OAuthException(AuthenticationException):
+    def __init__(self, error='', error_description=''):
+        super().__init__(self)
+        self.error = error
+        self.error_description = error_description
+
+
 class ProtocolException(OkException):
     """Exceptions related to protocol errors."""
 

--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -7,7 +7,7 @@ import time
 from urllib.parse import urlencode, urlparse, parse_qsl
 import webbrowser
 
-from client.exceptions import AuthenticationException
+from client.exceptions import AuthenticationException, OAuthException
 from client.utils.config import (CONFIG_DIRECTORY, REFRESH_FILE,
                                  create_config_directory)
 from client.utils import format, network
@@ -48,11 +48,6 @@ PASTE_MESSAGE = """
 After logging in, copy the code from the web page, paste it below,
 and press Enter. To paste, right-click and select "Paste".
 """.strip()
-
-class OAuthException(Exception):
-    def __init__(self, error='', error_description=''):
-        self.error = error
-        self.error_description = error_description
 
 def pick_free_port(hostname=REDIRECT_HOST, port=0):
     """ Try to bind a port. Default=0 selects a free port. """

--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -49,6 +49,14 @@ After logging in, copy the code from the web page, paste it below,
 and press Enter. To paste, right-click and select "Paste".
 """.strip()
 
+HOSTNAME_ERROR_MESSAGE = """
+Python couldn't recognize your computer's hostname because it contains
+non-ASCII characters (e.g. Non-English characters or accent marks).
+
+To fix, either upgrade Python to version 3.5.2+, or change your hostname.
+""".strip()
+
+
 def pick_free_port(hostname=REDIRECT_HOST, port=0):
     """ Try to bind a port. Default=0 selects a free port. """
     import socket
@@ -155,14 +163,17 @@ def refresh_local_token(server):
 def perform_oauth(code_fn, *args, **kwargs):
     try:
         access_token, expires_in, refresh_token = code_fn(*args, **kwargs)
+    except UnicodeDecodeError as e:
+        with format.block('-'):
+            print("Authentication error\n:{}".format(HOSTNAME_ERROR_MESSAGE))
     except OAuthException as e:
         with format.block('-'):
             print("Authentication error: {}".format(e.error.replace('_', ' ')))
             if e.error_description:
                 print(e.error_description)
-        return None
-    update_storage(access_token, expires_in, refresh_token)
-    return access_token
+    else:
+        update_storage(access_token, expires_in, refresh_token)
+        return access_token
 
 def server_url(cmd_args):
     scheme = 'http' if cmd_args.insecure else 'https'

--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -13,6 +13,7 @@ from client.utils.config import (CONFIG_DIRECTORY, REFRESH_FILE,
 from client.utils import format, network
 
 import logging
+import traceback
 
 log = logging.getLogger(__name__)
 
@@ -251,11 +252,13 @@ def get_code(cmd_args, endpoint=''):
         'scope': OAUTH_SCOPE,
     }
     url = '{}{}?{}'.format(server_url(cmd_args), AUTH_ENDPOINT, urlencode(params))
-    if webbrowser.open_new(url):
+    try:
+        assert webbrowser.open_new(url)
         return get_code_via_browser(cmd_args, redirect_uri,
             host_name, port_number, endpoint)
-    else:
-        log.warning('Failed to open browser, falling back to browserless auth')
+    except Exception as e:
+        log.debug('Error with Browser Auth:\n{}'.format(traceback.format_exc()))
+        log.warning('Browser auth failed, falling back to browserless auth')
         return get_code_via_terminal(cmd_args, email)
 
 def get_code_via_browser(cmd_args, redirect_uri, host_name, port_number, endpoint):


### PR DESCRIPTION
- Catches Errors pertaining to non-ASCII hostnames (e.g. when a hostname has non-english characters)  #309, #181 
- Auto fallback to browser less auth when browser-based auth fails
- Add better logging for exceptions, so we can debug more easily using `--debug`