### PR TITLE
Add simple hints to rate limiting

### DIFF
--- a/client/protocols/rate_limit.py
+++ b/client/protocols/rate_limit.py
@@ -41,9 +41,10 @@ to visualize Python's process with
 """
 
 DIAGRAM = \
-"""Try walking through your approach with a friend and drawing
-your solution on the board. Verify that the strategy matches
-with the implementation.
+"""Try walking through your approach with a friend and
+diagramming your solution. Verify that each step matches with
+the implementation by working through smaller examples in the
+interpreter or with your friend.
 """
 
 HINTS = (

--- a/client/protocols/rate_limit.py
+++ b/client/protocols/rate_limit.py
@@ -4,20 +4,73 @@ from client.utils.storage import contains, get, store
 import time
 import textwrap
 
+class Hint:
+    def __init__(self, text='', cooldown=0):
+        self.text = text
+        self.cooldown = cooldown
 
-COOLDOWN_POLICY = (0, 60,) # uniform 60s cooldown
+Hint.NONE = Hint()
 
-
-COOLDOWN_MSG = \
+EXAMPLES = \
+"""Try explaining the problem, its domain (inputs), range (outputs),
+and behavior in your own words. Come up with a few example inputs
+and outputs.
 """
-You're spamming the autograder for "{question}"!
-Please wait {wait}s... (attempts so far: {tries})
 
-If you're stuck on "{question}", try talking to your neighbor,
-asking for help, or running your code in interactive mode:
+PROCESS = \
+"""Try identifying where you are in the problem-solving process
+
+    https://cs61a.org/articles/studying.html#solving-problems
+"""
+
+TEST = \
+"""Try testing a few of your own examples in the interpreter:
 
     python3 -i {files}
 
+You can also run the doctests:
+
+    python3 -m doctest {files}
+"""
+
+PYTHON_TUTOR = \
+"""Try plugging the code along with an example into Python Tutor
+to visualize Python's process with
+
+    http://tutor.cs61a.org
+"""
+
+DIAGRAM = \
+"""Try walking through your approach with a friend and drawing
+your solution on the board. Verify that the strategy matches
+with the implementation.
+"""
+
+HINTS = (
+        Hint.NONE, Hint.NONE, Hint.NONE,
+        Hint(EXAMPLES, 30),
+        Hint.NONE, Hint.NONE, Hint.NONE,
+        Hint(PROCESS, 45),
+        Hint.NONE, Hint.NONE, Hint.NONE,
+        Hint(TEST, 60),
+        Hint.NONE, Hint.NONE, Hint.NONE,
+        Hint(PYTHON_TUTOR, 75),
+        Hint.NONE, Hint.NONE, Hint.NONE,
+        Hint(DIAGRAM, 90),
+        )
+
+
+COOLDOWN_MSG = \
+"""Woah, you're working really fast!
+Spend a minute or two applying this hint before trying again.
+
+"""
+
+RETRY_MSG = \
+"""
+If you're convinced you've fixed the problem, spend some time
+reflecting on the solution process and how you implemented
+any fixes along the way.
 """
 
 
@@ -28,8 +81,8 @@ asking for help, or running your code in interactive mode:
 class RateLimitProtocol(models.Protocol):
     """A Protocol that keeps track of rate limiting for specific questions.
     """
-    def __init__(self, args, assignment, cooldown=COOLDOWN_POLICY):
-        self.cooldown = cooldown
+    def __init__(self, args, assignment, hints=HINTS):
+        self.hints = hints
         super().__init__(args, assignment)
 
     def run(self, messages):
@@ -43,7 +96,8 @@ class RateLimitProtocol(models.Protocol):
             last_attempt, attempts = self.check_attempt(test)
             analytics[test.name] = {
                 'attempts': store(test.name, 'attempts', attempts),
-                'last_attempt': store(test.name, 'last_attempt', last_attempt)}
+                'last_attempt': store(test.name, 'last_attempt', last_attempt),
+                }
 
         messages['rate_limit'] = analytics
 
@@ -51,13 +105,14 @@ class RateLimitProtocol(models.Protocol):
         now = int(time.time())
         last_attempt = get(test.name, 'last_attempt', now)
         attempts = get(test.name, 'attempts', 0)
-        secs_elapsed = now - last_attempt
-        cooldown_time = self.cooldown[attempts] if attempts < len(self.cooldown) else self.cooldown[-1]
-        cooldown = cooldown_time - secs_elapsed
-        if attempts and cooldown > 0:
+        elapsed = now - last_attempt
+        hint = self.hints[attempts % len(self.hints)]
+        if attempts and hint.cooldown > elapsed:
             files = ' '.join(self.assignment.src)
-            raise EarlyExit(COOLDOWN_MSG.format(
-                wait=cooldown, question=test.name.lower(), tries=attempts, files=files))
+            if elapsed <= 0.1 * hint.cooldown:
+                raise EarlyExit(COOLDOWN_MSG + hint.text.format(files=files))
+            else:
+                raise EarlyExit(hint.text.format(files=files) + RETRY_MSG)
         return now, attempts + 1
 
 protocol = RateLimitProtocol

--- a/tests/protocols/rate_limit_test.py
+++ b/tests/protocols/rate_limit_test.py
@@ -18,7 +18,13 @@ class RateLimitProtocolTest(unittest.TestCase):
         self.cmd_args.restore = False
         self.assignment = mock.Mock(spec=Assignment)
         self.assignment.src = ['foo.py', 'bar.py']
-        self.proto = rate_limit.protocol(self.cmd_args, self.assignment, cooldown=(0,0,2,4))
+        self.proto = rate_limit.protocol(self.cmd_args, self.assignment,
+                hints=(
+                    rate_limit.Hint.NONE,
+                    rate_limit.Hint.NONE,
+                    rate_limit.Hint('a', 2),
+                    rate_limit.Hint('b', 4),
+                    ))
         self.test = mock.Mock(spec=models.Test)
         self.test.name = 'test'
 
@@ -67,7 +73,13 @@ class RateLimitProtocolTest(unittest.TestCase):
     def testSuppressOnUnlock(self):
         # set unlock (-u)
         self.cmd_args.unlock = True
-        self.proto = rate_limit.protocol(self.cmd_args, self.assignment, cooldown=(0,0,2,4))
+        self.proto = rate_limit.protocol(self.cmd_args, self.assignment,
+                hints=(
+                    rate_limit.Hint.NONE,
+                    rate_limit.Hint.NONE,
+                    rate_limit.Hint('a', 2),
+                    rate_limit.Hint('b', 4),
+                    ))
         # successive attempts should not cooldown
         # attempts not tracked when unlocking
         self.make_attempt(self.test, 0)


### PR DESCRIPTION
Converts rate limiting into more of a lightweight hint system so it will hopefully cause less irritation by now suggesting a task and setting the cooldown as a function of the expected task length. In addition, the system gets out of the way with more freebies.

Resolves #317 and #318.

- [x] Write tests