### PR TITLE
Tune rate limiting RETRY_THRESHOLD

### DIFF
--- a/client/protocols/rate_limit.py
+++ b/client/protocols/rate_limit.py
@@ -74,6 +74,8 @@ reflecting on the solution process and how you implemented
 any fixes along the way.
 """
 
+RETRY_THRESHOLD = 0.5 # How long into the cooldown until we switch to RETRY_MSG
+
 
 ###########################
 # Rate Limiting Mechanism #
@@ -110,7 +112,7 @@ class RateLimitProtocol(models.Protocol):
         hint = self.hints[attempts % len(self.hints)]
         if attempts and hint.cooldown > elapsed:
             files = ' '.join(self.assignment.src)
-            if elapsed <= 0.1 * hint.cooldown:
+            if elapsed <= RETRY_THRESHOLD * hint.cooldown:
                 raise EarlyExit(COOLDOWN_MSG + hint.text.format(files=files))
             else:
                 raise EarlyExit(hint.text.format(files=files) + RETRY_MSG)


### PR DESCRIPTION
Bump `RETRY_MSG` usage starting from 0.1 of the cooldown period to 0.5 of the cooldown period.