### PR TITLE
Fix OAuthException in notebook_authenticate

### DIFF
--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -88,7 +88,6 @@ def make_token_post(server, data):
             error='Authentication Failed',
             error_description=str(e))
     if 'error' in body:
-        log.error(body)
         raise OAuthException(
             error=body.get('error', 'Unknown Error'),
             error_description = body.get('error_description', ''))
@@ -204,7 +203,11 @@ def notebook_authenticate(cmd_args, force=False):
     network.check_ssl()
     access_token = None
     if not force:
-        access_token = refresh_local_token(server)
+        try:
+            access_token = refresh_local_token(server)
+        except OAuthException:
+            # Account for Invalid Grant Error During make_token_post
+            return notebook_authenticate(cmd_args, force=True)
 
     if not access_token:
         access_token = perform_oauth(

--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -211,7 +211,7 @@ def notebook_authenticate(cmd_args, force=False, silent=True):
             # Account for Invalid Grant Error During make_token_post
             if not silent:
                 raise e
-            return notebook_authenticate(cmd_args, force=True)
+            return notebook_authenticate(cmd_args, force=True, silent=False)
 
     if not access_token:
         access_token = perform_oauth(

--- a/client/utils/auth.py
+++ b/client/utils/auth.py
@@ -88,6 +88,7 @@ def make_token_post(server, data):
             error='Authentication Failed',
             error_description=str(e))
     if 'error' in body:
+        log.error(body)
         raise OAuthException(
             error=body.get('error', 'Unknown Error'),
             error_description = body.get('error_description', ''))
@@ -195,9 +196,10 @@ def authenticate(cmd_args, endpoint='', force=False):
 
     return access_token
 
-def notebook_authenticate(cmd_args, force=False):
+def notebook_authenticate(cmd_args, force=False, silent=True):
     """ Similiar to authenticate but prints student emails after
-    all calls and uses a different way to get codes.
+    all calls and uses a different way to get codes. If SILENT is True,
+    it will supprese the error messege and redirect to FORCE=True
     """
     server = server_url(cmd_args)
     network.check_ssl()
@@ -205,8 +207,10 @@ def notebook_authenticate(cmd_args, force=False):
     if not force:
         try:
             access_token = refresh_local_token(server)
-        except OAuthException:
+        except OAuthException as e:
             # Account for Invalid Grant Error During make_token_post
+            if not silent:
+                raise e
             return notebook_authenticate(cmd_args, force=True)
 
     if not access_token:


### PR DESCRIPTION
This PR fix a issue common in DS100 assignment notebooks.
When students encounter `ok.auth()`, they either have no issue
logging in or they encounter an Oauth error, which they have
to use `ok.auth(force=True)` to force authenticate.

This PR does just one thing: it catches the OAuthException and
redirect to the `ok.auth(force=True)` version. Thus student
don't have to guess which command to put in.

Technically, I
- remove the error logging message that will show up in notebook.
- catch the OAuthException and return a `force=True` version of it.

<Simon Mo>