### PR TITLE
Use os.remove, os.rename instead of os.replace for Windows

### DIFF
--- a/client/sources/ok_test/models.py
+++ b/client/sources/ok_test/models.py
@@ -179,8 +179,9 @@ class OkTest(models.Test):
         with open(test_tmp, 'w', encoding='utf-8') as f:
             f.write('test = {}\n'.format(json))
 
-        # Use an atomic rename operation to prevent test corruption
-        os.replace(test_tmp, self.file)
+        # Remove the file then rename instead of os.replace (ref issue #339)
+        os.remove(self.file)
+        os.rename(test_tmp, self.file)
 
     @property
     def unique_id_prefix(self):

--- a/client/sources/ok_test/models.py
+++ b/client/sources/ok_test/models.py
@@ -179,9 +179,14 @@ class OkTest(models.Test):
         with open(test_tmp, 'w', encoding='utf-8') as f:
             f.write('test = {}\n'.format(json))
 
-        # Remove the file then rename instead of os.replace (ref issue #339)
-        os.remove(self.file)
-        os.rename(test_tmp, self.file)
+        # Try to use os.replace, but if on Windows manually remove then rename
+        # (ref issue #339)
+        if os.name == 'nt':
+        # TODO(colin) Add additional error handling in case process gets killed mid remove/rename
+            os.remove(self.file)
+            os.rename(test_tmp, self.file)
+        else:
+            os.replace(test_tmp, self.file)
 
     @property
     def unique_id_prefix(self):


### PR DESCRIPTION
Fixes issue #339 

As per the documentation of  `os.replace` will may fail if src and dst are on different filesystems. This was happening for a student on Windows. 

It was also incorrectly commented before that this `os.replace` operation was atomic. That is false. It is not guaranteed to be atomic on Windows. It's impossible to guarantee an atomic renaming/replace operation on Windows if the file exists. This is the WinAPI call that is made (https://msdn.microsoft.com/en-us/library/aa365512(VS.85).aspx). It is actually a merge operation that has no guarantee of atomicity. 

This PR should fix the issue for this student. We should add some error handing in the future in case this process gets terminated mid remove/rename. 

Signed-off-by: Colin Schoen <cschoen@berkeley.edu>