### PR TITLE
Use `repl_str` in SchemeConsole

### DIFF
--- a/client/sources/ok_test/scheme.py
+++ b/client/sources/ok_test/scheme.py
@@ -33,6 +33,10 @@ class SchemeConsole(interpreter.Console):
         Loads the Scheme module before loading any code.
         """
         self._import_scheme()
+        try:
+            self._output_fn = self.scheme.repl_str
+        except:
+            pass
         super().load(code, setup, teardown)
         self._frame = self.scheme.create_global_frame()
 


### PR DESCRIPTION
Resolves #342.

This ensures that `#t` and `#f` are displayed correctly in all tests. It depends on version 1.2.3 of the Python-based Scheme interpreter (release in progress on staff repo).